### PR TITLE
Add audio recording and playback support

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -26,6 +26,7 @@ interface Wish {
   text: string;
   category: string;
   likes: number;
+  audioUrl?: string;
 }
 
 const allCategories = ['love', 'health', 'career', 'general', 'money', 'friendship'];
@@ -88,7 +89,7 @@ export default function ExploreScreen() {
 
   const renderWish = ({ item }: { item: Wish }) => (
     <View style={styles.wishItem}>
-      <Text style={styles.wishCategory}>#{item.category}</Text>
+      <Text style={styles.wishCategory}>#{item.category} {item.audioUrl ? '🔊' : ''}</Text>
       <Text style={styles.wishText}>{item.text}</Text>
       <Text style={styles.likes}>❤️ {item.likes}</Text>
     </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { router } from 'expo-router';
+import { Audio } from 'expo-av';
 import {
   addDoc,
   collection,
@@ -15,6 +16,7 @@ import {
   serverTimestamp,
   updateDoc,
 } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
@@ -31,7 +33,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { db } from '../../firebase';
+import { db, storage } from '../../firebase';
 
 interface Wish {
   id: string;
@@ -39,6 +41,7 @@ interface Wish {
   category: string;
   likes: number;
   pushToken?: string;
+  audioUrl?: string;
 }
 
 export default function IndexScreen() {
@@ -48,6 +51,9 @@ export default function IndexScreen() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [pushToken, setPushToken] = useState<string | null>(null);
+  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+  const [recordedUri, setRecordedUri] = useState<string | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
 
   useEffect(() => {
     registerForPushNotificationsAsync().then(setPushToken);
@@ -65,19 +71,66 @@ export default function IndexScreen() {
     return () => unsubscribe();
   }, []);
 
+  const startRecording = async () => {
+    try {
+      const { granted } = await Audio.requestPermissionsAsync();
+      if (!granted) {
+        Alert.alert('Permission required', 'Microphone access is needed to record');
+        return;
+      }
+      await Audio.setAudioModeAsync({
+        allowsRecordingIOS: true,
+        playsInSilentModeIOS: true,
+      });
+      const rec = new Audio.Recording();
+      await rec.prepareToRecordAsync(
+        Audio.RecordingOptionsPresets.HIGH_QUALITY
+      );
+      await rec.startAsync();
+      setRecording(rec);
+      setIsRecording(true);
+    } catch (err) {
+      console.error('❌ Failed to start recording:', err);
+    }
+  };
+
+  const stopRecording = async () => {
+    try {
+      if (!recording) return;
+      await recording.stopAndUnloadAsync();
+      const uri = recording.getURI();
+      setRecordedUri(uri);
+    } catch (err) {
+      console.error('❌ Failed to stop recording:', err);
+    } finally {
+      setIsRecording(false);
+      setRecording(null);
+    }
+  };
+
   const handlePostWish = async () => {
     if (wish.trim() === '') return;
 
     try {
+      let audioUrl = '';
+      if (recordedUri) {
+        const resp = await fetch(recordedUri);
+        const blob = await resp.blob();
+        const storageRef = ref(storage, `audio/${Date.now()}.m4a`);
+        await uploadBytes(storageRef, blob);
+        audioUrl = await getDownloadURL(storageRef);
+      }
       await addDoc(collection(db, 'wishes'), {
         text: wish,
         category: category.trim().toLowerCase(),
         likes: 0,
         timestamp: serverTimestamp(),
         pushToken: pushToken || '',
+        audioUrl,
       });
       setWish('');
       setCategory('general');
+      setRecordedUri(null);
     } catch (error) {
       console.error('❌ Failed to post wish:', error);
     }
@@ -161,6 +214,21 @@ export default function IndexScreen() {
           onChangeText={setCategory}
         />
 
+        <TouchableOpacity
+          style={[
+            styles.recButton,
+            { backgroundColor: isRecording ? '#ef4444' : '#22c55e' },
+          ]}
+          onPress={isRecording ? stopRecording : startRecording}
+        >
+          <Text style={styles.buttonText}>
+            {isRecording ? 'Stop Recording' : 'Record Audio'}
+          </Text>
+        </TouchableOpacity>
+        {recordedUri && !isRecording && (
+          <Text style={styles.recordingStatus}>Audio ready to upload</Text>
+        )}
+
         <Pressable
           style={[styles.button, { opacity: wish.trim() === '' ? 0.5 : 1 }]}
           onPress={handlePostWish}
@@ -184,7 +252,7 @@ export default function IndexScreen() {
             renderItem={({ item }) => (
               <TouchableOpacity onPress={() => router.push(`/wish/${item.id}`)}>
                 <View style={styles.wishItem}>
-                  <Text style={{ color: '#a78bfa', fontSize: 12 }}>#{item.category}</Text>
+                  <Text style={{ color: '#a78bfa', fontSize: 12 }}>#{item.category} {item.audioUrl ? '🔊' : ''}</Text>
                   <Text style={styles.wishText}>{item.text}</Text>
                   <Text style={styles.likeText}>❤️ {item.likes}</Text>
                 </View>
@@ -233,9 +301,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 20,
   },
+  recButton: {
+    padding: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginBottom: 10,
+  },
   buttonText: {
     color: '#fff',
     fontWeight: '600',
+  },
+  recordingStatus: {
+    color: '#22c55e',
+    textAlign: 'center',
+    marginBottom: 10,
   },
   authButton: {
     marginBottom: 20,

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -2,6 +2,7 @@
 import { formatDistanceToNow } from 'date-fns';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { Audio } from 'expo-av';
 import {
   addDoc,
   collection,
@@ -33,6 +34,7 @@ interface Wish {
   text: string;
   category: string;
   likes: number;
+  audioUrl?: string;
 }
 
 interface Comment {
@@ -55,6 +57,7 @@ export default function WishDetailScreen() {
   const [nickname, setNickname] = useState('');
   const [comments, setComments] = useState<Comment[]>([]);
   const [replyTo, setReplyTo] = useState<string | null>(null);
+  const [sound, setSound] = useState<Audio.Sound | null>(null);
   const flatListRef = useRef<FlatList>(null);
   const animationRefs = useRef<{ [key: string]: Animated.Value }>({});
 
@@ -100,6 +103,23 @@ export default function WishDetailScreen() {
     const unsubscribe = subscribeToComments();
     return unsubscribe;
   }, [subscribeToComments]);
+
+  const playAudio = useCallback(async () => {
+    if (!wish?.audioUrl) return;
+    try {
+      const { sound: newSound } = await Audio.Sound.createAsync({ uri: wish.audioUrl });
+      setSound(newSound);
+      await newSound.playAsync();
+    } catch (err) {
+      console.error('❌ Failed to play audio:', err);
+    }
+  }, [wish]);
+
+  useEffect(() => {
+    return () => {
+      sound?.unloadAsync();
+    };
+  }, [sound]);
 
   const handlePostComment = useCallback(async () => {
     if (!comment.trim()) return;
@@ -233,6 +253,11 @@ export default function WishDetailScreen() {
             <Text style={styles.wishCategory}>#{wish.category}</Text>
             <Text style={styles.wishText}>{wish.text}</Text>
             <Text style={styles.likes}>❤️ {wish.likes}</Text>
+            {wish.audioUrl && (
+              <TouchableOpacity onPress={playAudio} style={{ marginTop: 10 }}>
+                <Text style={{ color: '#a78bfa' }}>▶ Play Audio</Text>
+              </TouchableOpacity>
+            )}
           </View>
         )}
 

--- a/firebase.js
+++ b/firebase.js
@@ -1,6 +1,7 @@
 // firebase.js
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: "AIzaSyDVBdi1qJOtOPX6-jGOZgj8uwh9tM7uomc",
@@ -13,5 +14,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
-
-export { db };
+const storage = getStorage(app);
+export { db, storage };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.1.6",
         "date-fns": "^4.1.0",
         "expo": "~53.0.11",
+        "expo-av": "^15.1.6",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.6",
         "expo-device": "~7.1.4",
@@ -7570,6 +7571,23 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.6.tgz",
+      "integrity": "sha512-5ZbeXdCmdckZHwtEV+8tRZqLlUWR96gkkUIxpyZAEvK0L+aI/BnyhDCpjnSKWwZo4ZA6lx8/su9kyFNV/mQ/sQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-blur": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native": "^7.1.6",
     "date-fns": "^4.1.0",
     "expo": "~53.0.11",
+    "expo-av": "^15.1.6",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.6",
     "expo-device": "~7.1.4",


### PR DESCRIPTION
## Summary
- install expo-av for audio features
- expose Firebase storage in `firebase.js`
- extend `Wish` with optional `audioUrl`
- enable recording and uploading wishes with audio in home screen
- show audio icon on wishes lists
- allow playing wish audio in detail screen

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b5bdc53308327bfd27b8adf18aefb