### PR TITLE
Add category picker to Explore screen

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -11,7 +11,6 @@ import {
     ActivityIndicator,
     FlatList,
     SafeAreaView,
-    ScrollView,
     StatusBar,
     StyleSheet,
     Text,
@@ -19,6 +18,7 @@ import {
     TouchableOpacity,
     View,
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { db } from '../../firebase';
 
 interface Wish {
@@ -28,10 +28,10 @@ interface Wish {
   likes: number;
 }
 
-const allCategories = ['love', 'health', 'career', 'general', 'money', 'friendship'];
+const allCategories = ['love', 'health', 'career', 'general', 'money', 'friendship', 'fitness'];
 
 export default function ExploreScreen() {
-  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [filteredWishes, setFilteredWishes] = useState<Wish[]>([]);
   const [topWishes, setTopWishes] = useState<Wish[]>([]);
   const [loading, setLoading] = useState(true);
@@ -54,7 +54,7 @@ export default function ExploreScreen() {
       const all = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Wish[];
       const filtered = all.filter((wish) => {
         const inCategory =
-          trendingMode || selectedCategories.size === 0 || selectedCategories.has(wish.category);
+          trendingMode || !selectedCategory || wish.category === selectedCategory;
         const inSearch = wish.text.toLowerCase().includes(searchTerm.toLowerCase());
         return inCategory && inSearch;
       });
@@ -67,7 +67,7 @@ export default function ExploreScreen() {
   useEffect(() => {
     const unsubscribe = fetchWishes();
     return () => unsubscribe();
-  }, [selectedCategories, trendingMode, searchTerm]);
+  }, [selectedCategory, trendingMode, searchTerm]);
 
   const handleReload = () => {
     fetchWishes();
@@ -75,16 +75,8 @@ export default function ExploreScreen() {
 
   const toggleTrending = (mode: boolean) => {
     setTrendingMode(mode);
-    if (mode) {
-      setSelectedCategories(new Set());
-    }
   };
 
-  const toggleCategory = (cat: string) => {
-    const newSet = new Set(selectedCategories);
-    newSet.has(cat) ? newSet.delete(cat) : newSet.add(cat);
-    setSelectedCategories(newSet);
-  };
 
   const renderWish = ({ item }: { item: Wish }) => (
     <View style={styles.wishItem}>
@@ -123,21 +115,21 @@ export default function ExploreScreen() {
           </TouchableOpacity>
         </View>
 
-        {!trendingMode && (
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.categoryBar}>
-            {allCategories.map((cat) => (
-              <TouchableOpacity
-                key={cat}
-                onPress={() => toggleCategory(cat)}
-                style={[styles.categoryButton, selectedCategories.has(cat) && styles.activeCategory]}
-              >
-                <Text style={[styles.categoryText, selectedCategories.has(cat) && styles.activeCategoryText]}>
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </ScrollView>
-        )}
+        <Picker
+          selectedValue={selectedCategory}
+          onValueChange={(value) => setSelectedCategory(value)}
+          style={styles.dropdown}
+          dropdownIconColor="#fff"
+        >
+          <Picker.Item label="All Categories" value={null} />
+          {allCategories.map((cat) => (
+            <Picker.Item
+              key={cat}
+              label={cat.charAt(0).toUpperCase() + cat.slice(1)}
+              value={cat}
+            />
+          ))}
+        </Picker>
 
         {!trendingMode && topWishes.length > 0 && (
           <View style={styles.topSection}>
@@ -216,27 +208,11 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: 'bold',
   },
-  categoryBar: {
-    flexGrow: 0,
-    marginBottom: 16,
-  },
-  categoryButton: {
+  dropdown: {
     backgroundColor: '#1e1e1e',
-    paddingVertical: 8,
-    paddingHorizontal: 14,
-    borderRadius: 20,
-    marginRight: 10,
-  },
-  activeCategory: {
-    backgroundColor: '#8b5cf6',
-  },
-  categoryText: {
-    color: '#aaa',
-    fontSize: 14,
-  },
-  activeCategoryText: {
     color: '#fff',
-    fontWeight: 'bold',
+    borderRadius: 10,
+    marginBottom: 16,
   },
   sectionTitle: {
     color: '#fff',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
+        "@react-native-picker/picker": "^2.11.1",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -3540,6 +3541,19 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.1.tgz",
+      "integrity": "sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-picker/picker": "^2.11.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",


### PR DESCRIPTION
## Summary
- add `@react-native-picker/picker` dependency
- use single `selectedCategory` state in explore screen
- replace horizontal scroll of categories with Picker dropdown
- filter wishes by selectedCategory
- style new dropdown

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b5c4f2f188327ac58e86c6a35de70