### PR TITLE
Add loading spinners and error handling

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -35,32 +35,51 @@ export default function ExploreScreen() {
   const [filteredWishes, setFilteredWishes] = useState<Wish[]>([]);
   const [topWishes, setTopWishes] = useState<Wish[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [trendingMode, setTrendingMode] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
 
   useEffect(() => {
     const topQuery = query(collection(db, 'wishes'), orderBy('likes', 'desc'), limit(3));
-    const unsubscribe = onSnapshot(topQuery, (snapshot) => {
-      const top = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Wish[];
-      setTopWishes(top);
-    });
+    const unsubscribe = onSnapshot(
+      topQuery,
+      (snapshot) => {
+        const top = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Wish[];
+        setTopWishes(top);
+      },
+      (err) => {
+        console.error('❌ Failed to load top wishes:', err);
+        setError('Failed to load wishes');
+      }
+    );
     return () => unsubscribe();
   }, []);
 
   const fetchWishes = () => {
     setLoading(true);
-    const baseQuery = query(collection(db, 'wishes'), orderBy(trendingMode ? 'likes' : 'timestamp', 'desc'));
-    const unsubscribe = onSnapshot(baseQuery, (snapshot) => {
-      const all = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Wish[];
-      const filtered = all.filter((wish) => {
-        const inCategory =
-          trendingMode || selectedCategories.size === 0 || selectedCategories.has(wish.category);
-        const inSearch = wish.text.toLowerCase().includes(searchTerm.toLowerCase());
-        return inCategory && inSearch;
-      });
-      setFilteredWishes(filtered);
-      setLoading(false);
-    });
+    const baseQuery = query(
+      collection(db, 'wishes'),
+      orderBy(trendingMode ? 'likes' : 'timestamp', 'desc')
+    );
+    const unsubscribe = onSnapshot(
+      baseQuery,
+      (snapshot) => {
+        const all = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })) as Wish[];
+        const filtered = all.filter((wish) => {
+          const inCategory =
+            trendingMode || selectedCategories.size === 0 || selectedCategories.has(wish.category);
+          const inSearch = wish.text.toLowerCase().includes(searchTerm.toLowerCase());
+          return inCategory && inSearch;
+        });
+        setFilteredWishes(filtered);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('❌ Failed to load wishes:', err);
+        setError('Failed to load wishes');
+        setLoading(false);
+      }
+    );
     return unsubscribe;
   };
 
@@ -153,6 +172,8 @@ export default function ExploreScreen() {
 
         {loading ? (
           <ActivityIndicator size="large" color="#a78bfa" style={{ marginTop: 20 }} />
+        ) : error ? (
+          <Text style={styles.errorText}>{error}</Text>
         ) : filteredWishes.length === 0 ? (
           <Text style={styles.noResults}>No matching wishes 💭</Text>
         ) : (
@@ -288,6 +309,11 @@ const styles = StyleSheet.create({
     color: '#f472b6',
     fontSize: 14,
     fontWeight: '500',
+  },
+  errorText: {
+    color: '#f87171',
+    textAlign: 'center',
+    marginTop: 20,
   },
   noResults: {
     color: '#ccc',

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -29,18 +29,21 @@ export default function ProfileScreen() {
   const [badges, setBadges] = useState<string[]>([]);
   const [categoryData, setCategoryData] = useState<{ category: string; count: number }[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
   useEffect(() => {
     const loadData = async () => {
       setLoading(true);
-      const stored = await AsyncStorage.getItem('nickname');
-      if (!stored) {
-        setLoading(false);
-        return;
-      }
-      setNickname(stored);
-      setInputName(stored);
+      setError(null);
+      try {
+        const stored = await AsyncStorage.getItem('nickname');
+        if (!stored) {
+          setLoading(false);
+          return;
+        }
+        setNickname(stored);
+        setInputName(stored);
 
       const wishesSnap = await getDocs(query(collection(db, 'wishes'), where('nickname', '==', stored)));
       const wishes: any[] = [];
@@ -125,6 +128,11 @@ export default function ProfileScreen() {
 
       setBadges(badgeList);
       setLoading(false);
+    } catch (err) {
+      console.error('❌ Failed to load profile data:', err);
+      setError('Failed to load profile');
+      setLoading(false);
+    }
     };
     loadData();
   }, []);
@@ -142,6 +150,8 @@ export default function ProfileScreen() {
       <View style={styles.container}>
         {loading ? (
           <ActivityIndicator size="large" color="#a78bfa" style={{ marginTop: 20 }} />
+        ) : error ? (
+          <Text style={styles.errorText}>{error}</Text>
         ) : (
           <>
         <Text style={styles.header}>👤 {nickname || 'Anonymous'}</Text>
@@ -292,6 +302,11 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 10,
     marginBottom: 10,
+  },
+  errorText: {
+    color: '#f87171',
+    textAlign: 'center',
+    marginTop: 20,
   },
   button: {
     backgroundColor: '#8b5cf6',

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -15,17 +15,26 @@ export default function TrendingScreen() {
   const router = useRouter();
   const [wishes, setWishes] = useState<Wish[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const q = query(collection(db, 'wishes'), orderBy('likes', 'desc'), limit(20));
-    const unsubscribe = onSnapshot(q, (snapshot) => {
-      const data = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...(doc.data() as Omit<Wish, 'id'>),
-      }));
-      setWishes(data as Wish[]);
-      setLoading(false);
-    });
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const data = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...(doc.data() as Omit<Wish, 'id'>),
+        }));
+        setWishes(data as Wish[]);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('❌ Failed to load wishes:', err);
+        setError('Failed to load wishes');
+        setLoading(false);
+      }
+    );
     return () => unsubscribe();
   }, []);
 
@@ -46,6 +55,8 @@ export default function TrendingScreen() {
         <Text style={styles.title}>Trending Wishes 🔥</Text>
         {loading ? (
           <ActivityIndicator size="large" color="#a78bfa" style={{ marginTop: 20 }} />
+        ) : error ? (
+          <Text style={styles.errorText}>{error}</Text>
         ) : (
           <FlatList
             data={wishes}
@@ -96,5 +107,10 @@ const styles = StyleSheet.create({
     color: '#f472b6',
     fontSize: 14,
     fontWeight: '500',
+  },
+  errorText: {
+    color: '#f87171',
+    textAlign: 'center',
+    marginTop: 20,
   },
 });

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -16,6 +16,7 @@ import {
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
+  ActivityIndicator,
   FlatList,
   KeyboardAvoidingView,
   Platform,
@@ -55,14 +56,25 @@ export default function WishDetailScreen() {
   const [nickname, setNickname] = useState('');
   const [comments, setComments] = useState<Comment[]>([]);
   const [replyTo, setReplyTo] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const flatListRef = useRef<FlatList>(null);
   const animationRefs = useRef<{ [key: string]: Animated.Value }>({});
 
   const fetchWish = useCallback(async () => {
-    const ref = doc(db, 'wishes', id as string);
-    const snap = await getDoc(ref);
-    if (snap.exists()) {
-      setWish({ id: snap.id, ...(snap.data() as Omit<Wish, 'id'>) });
+    setLoading(true);
+    setError(null);
+    try {
+      const ref = doc(db, 'wishes', id as string);
+      const snap = await getDoc(ref);
+      if (snap.exists()) {
+        setWish({ id: snap.id, ...(snap.data() as Omit<Wish, 'id'>) });
+      }
+    } catch (err) {
+      console.error('❌ Failed to load wish:', err);
+      setError('Failed to load wish');
+    } finally {
+      setLoading(false);
     }
   }, [id]);
 
@@ -74,26 +86,36 @@ export default function WishDetailScreen() {
     const commentsRef = collection(db, 'wishes', id as string, 'comments');
     const q = query(commentsRef, orderBy('timestamp', 'asc'));
 
-    return onSnapshot(q, (snapshot) => {
-      const list = snapshot.docs.map((d) => {
-        const commentId = d.id;
-        if (!animationRefs.current[commentId]) {
-          animationRefs.current[commentId] = new Animated.Value(0);
-        }
-        const data = d.data() as Omit<Comment, 'id'> & { parentId?: string };
-        return { id: d.id, ...data };
-      }) as Comment[];
+    setLoading(true);
+    return onSnapshot(
+      q,
+      (snapshot) => {
+        const list = snapshot.docs.map((d) => {
+          const commentId = d.id;
+          if (!animationRefs.current[commentId]) {
+            animationRefs.current[commentId] = new Animated.Value(0);
+          }
+          const data = d.data() as Omit<Comment, 'id'> & { parentId?: string };
+          return { id: d.id, ...data };
+        }) as Comment[];
 
-      const sorted = [...list].sort((a, b) => {
-        const aCount = Object.values(a.reactions || {}).reduce((s, v) => s + v, 0);
-        const bCount = Object.values(b.reactions || {}).reduce((s, v) => s + v, 0);
-        return bCount - aCount;
-      });
-      setComments(sorted);
-      setTimeout(() => {
-        flatListRef.current?.scrollToEnd({ animated: true });
-      }, 300);
-    });
+        const sorted = [...list].sort((a, b) => {
+          const aCount = Object.values(a.reactions || {}).reduce((s, v) => s + v, 0);
+          const bCount = Object.values(b.reactions || {}).reduce((s, v) => s + v, 0);
+          return bCount - aCount;
+        });
+        setComments(sorted);
+        setLoading(false);
+        setTimeout(() => {
+          flatListRef.current?.scrollToEnd({ animated: true });
+        }, 300);
+      },
+      (err) => {
+        console.error('❌ Failed to load comments:', err);
+        setError('Failed to load comments');
+        setLoading(false);
+      }
+    );
   }, [id]);
 
   useEffect(() => {
@@ -228,21 +250,29 @@ export default function WishDetailScreen() {
           <Text style={styles.backButtonText}>← Back</Text>
         </TouchableOpacity>
 
-        {wish && (
-          <View style={styles.wishBox}>
-            <Text style={styles.wishCategory}>#{wish.category}</Text>
-            <Text style={styles.wishText}>{wish.text}</Text>
-            <Text style={styles.likes}>❤️ {wish.likes}</Text>
-          </View>
-        )}
+        {loading ? (
+          <ActivityIndicator size="large" color="#a78bfa" style={{ marginTop: 20 }} />
+        ) : error ? (
+          <Text style={styles.errorText}>{error}</Text>
+        ) : (
+          <>
+            {wish && (
+              <View style={styles.wishBox}>
+                <Text style={styles.wishCategory}>#{wish.category}</Text>
+                <Text style={styles.wishText}>{wish.text}</Text>
+                <Text style={styles.likes}>❤️ {wish.likes}</Text>
+              </View>
+            )}
 
-        <FlatList
-          ref={flatListRef}
-          data={comments.filter((c) => !c.parentId)}
-          keyExtractor={(item) => item.id}
-          renderItem={renderComment}
-          contentContainerStyle={{ paddingBottom: 80 }}
-        />
+            <FlatList
+              ref={flatListRef}
+              data={comments.filter((c) => !c.parentId)}
+              keyExtractor={(item) => item.id}
+              renderItem={renderComment}
+              contentContainerStyle={{ paddingBottom: 80 }}
+            />
+          </>
+        )}
 
         {replyTo && (
           <View style={styles.replyInfo}>
@@ -346,6 +376,11 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 10,
     marginBottom: 10,
+  },
+  errorText: {
+    color: '#f87171',
+    textAlign: 'center',
+    marginTop: 20,
   },
   button: {
     backgroundColor: '#8b5cf6',


### PR DESCRIPTION
## Summary
- display error messages in all wish/comment screens
- add loading state to wish detail page
- handle fetch errors from Firestore queries

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5ca965b883278c8ab3897fd2d090