### PR TITLE
Add theme toggle with context

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 // app/(tabs)/_layout.tsx — Enhanced Tab Navigation Layout with Daily Wish Streak
 import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
-import { useColorScheme } from 'react-native';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
@@ -49,6 +49,15 @@ export default function TabLayout() {
           title: 'Profile',
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="person-circle-outline" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="settings-outline" color={color} size={size} />
           ),
         }}
       />

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StyleSheet, Switch } from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { useTheme } from '@/contexts/ThemeContext';
+
+export default function SettingsScreen() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText style={styles.label}>Dark Mode</ThemedText>
+      <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  label: {
+    marginBottom: 12,
+    fontSize: 18,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-
 import { Slot } from 'expo-router';
-
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 export default function RootLayout() {
-  return <Slot />;
+  return (
+    <ThemeProvider>
+      <Slot />
+    </ThemeProvider>
+  );
 }

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState } from 'react';
+import { useColorScheme as useRNColorScheme } from 'react-native';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const systemTheme = useRNColorScheme() as Theme;
+  const [theme, setTheme] = useState<Theme>(systemTheme ?? 'light');
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);
+export { ThemeContext };

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,7 @@
-export { useColorScheme } from 'react-native';
+import { useContext } from 'react';
+import { ThemeContext } from '@/contexts/ThemeContext';
+
+export function useColorScheme() {
+  const { theme } = useContext(ThemeContext);
+  return theme;
+}

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,20 +1,19 @@
-import { useEffect, useState } from 'react';
-import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useEffect, useState, useContext } from 'react';
+import { ThemeContext } from '@/contexts/ThemeContext';
 
 /**
  * To support static rendering, this value needs to be re-calculated on the client side for web
  */
 export function useColorScheme() {
+  const { theme } = useContext(ThemeContext);
   const [hasHydrated, setHasHydrated] = useState(false);
 
   useEffect(() => {
     setHasHydrated(true);
   }, []);
 
-  const colorScheme = useRNColorScheme();
-
   if (hasHydrated) {
-    return colorScheme;
+    return theme;
   }
 
   return 'light';


### PR DESCRIPTION
## Summary
- implement `ThemeContext` for dark/light theme switching
- update color scheme hooks to use new context
- wrap app layout with `ThemeProvider`
- add settings screen with theme toggle
- include settings tab in navigation

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b5cc39ca88327bd64c6247f13ad03