### PR TITLE
Add optional poll mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ npm run reset-project
 
 This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
 
+## Poll Mode
+
+Wishes can optionally include a poll with two text choices. Enable **Poll Mode** on the home screen to add options A and B when posting a wish. Vote results update in real time on the wish detail screen.
+
 ## Learn more
 
 To learn more about developing your project with Expo, look at the following resources:

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -26,6 +26,11 @@ interface Wish {
   text: string;
   category: string;
   likes: number;
+  isPoll?: boolean;
+  optionA?: string;
+  optionB?: string;
+  votesA?: number;
+  votesB?: number;
 }
 
 const allCategories = ['love', 'health', 'career', 'general', 'money', 'friendship'];
@@ -90,7 +95,14 @@ export default function ExploreScreen() {
     <View style={styles.wishItem}>
       <Text style={styles.wishCategory}>#{item.category}</Text>
       <Text style={styles.wishText}>{item.text}</Text>
-      <Text style={styles.likes}>❤️ {item.likes}</Text>
+      {item.isPoll ? (
+        <View style={{ marginTop: 6 }}>
+          <Text style={styles.pollText}>{item.optionA}: {item.votesA || 0}</Text>
+          <Text style={styles.pollText}>{item.optionB}: {item.votesB || 0}</Text>
+        </View>
+      ) : (
+        <Text style={styles.likes}>❤️ {item.likes}</Text>
+      )}
     </View>
   );
 
@@ -288,6 +300,10 @@ const styles = StyleSheet.create({
     color: '#f472b6',
     fontSize: 14,
     fontWeight: '500',
+  },
+  pollText: {
+    color: '#fff',
+    fontSize: 14,
   },
   noResults: {
     color: '#ccc',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -28,6 +28,7 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  Switch,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -39,6 +40,11 @@ interface Wish {
   category: string;
   likes: number;
   pushToken?: string;
+  isPoll?: boolean;
+  optionA?: string;
+  optionB?: string;
+  votesA?: number;
+  votesB?: number;
 }
 
 export default function IndexScreen() {
@@ -48,6 +54,9 @@ export default function IndexScreen() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [pushToken, setPushToken] = useState<string | null>(null);
+  const [isPoll, setIsPoll] = useState(false);
+  const [optionA, setOptionA] = useState('');
+  const [optionB, setOptionB] = useState('');
 
   useEffect(() => {
     registerForPushNotificationsAsync().then(setPushToken);
@@ -75,9 +84,19 @@ export default function IndexScreen() {
         likes: 0,
         timestamp: serverTimestamp(),
         pushToken: pushToken || '',
+        ...(isPoll && {
+          isPoll: true,
+          optionA: optionA.trim(),
+          optionB: optionB.trim(),
+          votesA: 0,
+          votesB: 0,
+        }),
       });
       setWish('');
       setCategory('general');
+      setOptionA('');
+      setOptionB('');
+      setIsPoll(false);
     } catch (error) {
       console.error('❌ Failed to post wish:', error);
     }
@@ -161,6 +180,30 @@ export default function IndexScreen() {
           onChangeText={setCategory}
         />
 
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
+          <Text style={{ color: '#fff', marginRight: 8 }}>Poll Mode</Text>
+          <Switch value={isPoll} onValueChange={setIsPoll} />
+        </View>
+
+        {isPoll && (
+          <>
+            <TextInput
+              style={styles.input}
+              placeholder="Option A"
+              placeholderTextColor="#999"
+              value={optionA}
+              onChangeText={setOptionA}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="Option B"
+              placeholderTextColor="#999"
+              value={optionB}
+              onChangeText={setOptionB}
+            />
+          </>
+        )}
+
         <Pressable
           style={[styles.button, { opacity: wish.trim() === '' ? 0.5 : 1 }]}
           onPress={handlePostWish}
@@ -186,7 +229,14 @@ export default function IndexScreen() {
                 <View style={styles.wishItem}>
                   <Text style={{ color: '#a78bfa', fontSize: 12 }}>#{item.category}</Text>
                   <Text style={styles.wishText}>{item.text}</Text>
-                  <Text style={styles.likeText}>❤️ {item.likes}</Text>
+                  {item.isPoll ? (
+                    <View style={{ marginTop: 6 }}>
+                      <Text style={styles.pollText}>{item.optionA}: {item.votesA || 0}</Text>
+                      <Text style={styles.pollText}>{item.optionB}: {item.votesB || 0}</Text>
+                    </View>
+                  ) : (
+                    <Text style={styles.likeText}>❤️ {item.likes}</Text>
+                  )}
                 </View>
               </TouchableOpacity>
             )}
@@ -259,6 +309,10 @@ const styles = StyleSheet.create({
   likeText: {
     color: '#a78bfa',
     marginTop: 6,
+    fontSize: 14,
+  },
+  pollText: {
+    color: '#fff',
     fontSize: 14,
   },
   noResults: {

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -9,6 +9,11 @@ interface Wish {
   text: string;
   category: string;
   likes: number;
+  isPoll?: boolean;
+  optionA?: string;
+  optionB?: string;
+  votesA?: number;
+  votesB?: number;
 }
 
 export default function TrendingScreen() {
@@ -34,7 +39,14 @@ export default function TrendingScreen() {
       <View style={styles.wishItem}>
         <Text style={styles.wishCategory}>#{item.category}</Text>
         <Text style={styles.wishText}>{item.text}</Text>
-        <Text style={styles.likes}>❤️ {item.likes}</Text>
+        {item.isPoll ? (
+          <View style={{ marginTop: 6 }}>
+            <Text style={styles.pollText}>{item.optionA}: {item.votesA || 0}</Text>
+            <Text style={styles.pollText}>{item.optionB}: {item.votesB || 0}</Text>
+          </View>
+        ) : (
+          <Text style={styles.likes}>❤️ {item.likes}</Text>
+        )}
       </View>
     </TouchableOpacity>
   );
@@ -96,5 +108,9 @@ const styles = StyleSheet.create({
     color: '#f472b6',
     fontSize: 14,
     fontWeight: '500',
+  },
+  pollText: {
+    color: '#fff',
+    fontSize: 14,
   },
 });

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -1,16 +1,17 @@
 // app/wish/[id].tsx — detail view of a single wish
 import { formatDistanceToNow } from 'date-fns';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StatusBar } from 'expo-status-bar';
 import {
   addDoc,
   collection,
   doc,
-  getDoc,
   onSnapshot,
   orderBy,
   query,
   serverTimestamp,
+  increment,
   updateDoc,
 } from 'firebase/firestore';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -33,6 +34,11 @@ interface Wish {
   text: string;
   category: string;
   likes: number;
+  isPoll?: boolean;
+  optionA?: string;
+  optionB?: string;
+  votesA?: number;
+  votesB?: number;
 }
 
 interface Comment {
@@ -55,20 +61,28 @@ export default function WishDetailScreen() {
   const [nickname, setNickname] = useState('');
   const [comments, setComments] = useState<Comment[]>([]);
   const [replyTo, setReplyTo] = useState<string | null>(null);
+  const [hasVoted, setHasVoted] = useState(false);
   const flatListRef = useRef<FlatList>(null);
   const animationRefs = useRef<{ [key: string]: Animated.Value }>({});
 
-  const fetchWish = useCallback(async () => {
+  useEffect(() => {
     const ref = doc(db, 'wishes', id as string);
-    const snap = await getDoc(ref);
-    if (snap.exists()) {
-      setWish({ id: snap.id, ...(snap.data() as Omit<Wish, 'id'>) });
-    }
+    const unsubscribe = onSnapshot(ref, (snap) => {
+      if (snap.exists()) {
+        setWish({ id: snap.id, ...(snap.data() as Omit<Wish, 'id'>) });
+      }
+    });
+    return unsubscribe;
   }, [id]);
 
   useEffect(() => {
-    fetchWish();
-  }, [fetchWish]);
+    const checkVote = async () => {
+      const voted = await AsyncStorage.getItem('votedPolls');
+      const list = voted ? JSON.parse(voted) : [];
+      if (list.includes(id)) setHasVoted(true);
+    };
+    checkVote();
+  }, [id]);
 
   const subscribeToComments = useCallback(() => {
     const commentsRef = collection(db, 'wishes', id as string, 'comments');
@@ -151,6 +165,26 @@ export default function WishDetailScreen() {
     }
   }, [comments, id, nickname]);
 
+  const handleVote = useCallback(
+    async (option: 'A' | 'B') => {
+      if (!wish || hasVoted) return;
+      try {
+        const ref = doc(db, 'wishes', wish.id);
+        await updateDoc(ref, {
+          [option === 'A' ? 'votesA' : 'votesB']: increment(1),
+        });
+        const voted = await AsyncStorage.getItem('votedPolls');
+        const list = voted ? JSON.parse(voted) : [];
+        list.push(wish.id);
+        await AsyncStorage.setItem('votedPolls', JSON.stringify(list));
+        setHasVoted(true);
+      } catch (err) {
+        console.error('❌ Failed to vote:', err);
+      }
+    },
+    [hasVoted, wish]
+  );
+
 
   const renderCommentItem = useCallback(
     (item: Comment, level = 0) => {
@@ -232,7 +266,30 @@ export default function WishDetailScreen() {
           <View style={styles.wishBox}>
             <Text style={styles.wishCategory}>#{wish.category}</Text>
             <Text style={styles.wishText}>{wish.text}</Text>
-            <Text style={styles.likes}>❤️ {wish.likes}</Text>
+            {wish.isPoll ? (
+              <View style={{ marginTop: 8 }}>
+                <TouchableOpacity
+                  style={styles.pollOption}
+                  disabled={hasVoted}
+                  onPress={() => handleVote('A')}
+                >
+                  <Text style={styles.pollOptionText}>
+                    {wish.optionA} - {wish.votesA || 0}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.pollOption}
+                  disabled={hasVoted}
+                  onPress={() => handleVote('B')}
+                >
+                  <Text style={styles.pollOptionText}>
+                    {wish.optionB} - {wish.votesB || 0}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            ) : (
+              <Text style={styles.likes}>❤️ {wish.likes}</Text>
+            )}
           </View>
         )}
 
@@ -314,6 +371,16 @@ const styles = StyleSheet.create({
     color: '#a78bfa',
     fontSize: 14,
     marginTop: 8,
+  },
+  pollOption: {
+    backgroundColor: '#2e2e2e',
+    padding: 10,
+    borderRadius: 8,
+    marginTop: 6,
+  },
+  pollOptionText: {
+    color: '#fff',
+    textAlign: 'center',
   },
   commentBox: {
     backgroundColor: '#1a1a1a',


### PR DESCRIPTION
## Summary
- enable poll mode when posting wishes
- display vote counts in list views
- show poll voting on the wish detail screen
- document poll mode in README

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p . --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d0cb8088327b1b36f3afb6ae2f4