### PR TITLE
Refactor Firestore logic into helper module

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,17 +5,12 @@ import * as Notifications from 'expo-notifications';
 import { router } from 'expo-router';
 import { Audio } from 'expo-av';
 import {
-  addDoc,
-  collection,
-  doc,
-  getDoc,
-  increment,
-  onSnapshot,
-  orderBy,
-  query,
-  serverTimestamp,
-  updateDoc,
-} from 'firebase/firestore';
+  listenWishes,
+  addWish,
+  likeWish,
+  getWish,
+  Wish,
+} from '../../helpers/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import React, { useEffect, useState } from 'react';
 import {
@@ -33,16 +28,8 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { db, storage } from '../../firebase';
+import { storage } from '../../firebase';
 
-interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-  pushToken?: string;
-  audioUrl?: string;
-}
 
 export default function IndexScreen() {
   const [wish, setWish] = useState('');
@@ -58,16 +45,10 @@ export default function IndexScreen() {
   useEffect(() => {
     registerForPushNotificationsAsync().then(setPushToken);
 
-    const q = query(collection(db, 'wishes'), orderBy('timestamp', 'desc'));
-    const unsubscribe = onSnapshot(q, (snapshot) => {
-      const wishes = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      })) as Wish[];
-      setWishList(wishes);
+    const unsubscribe = listenWishes((w) => {
+      setWishList(w);
       setLoading(false);
     });
-
     return () => unsubscribe();
   }, []);
 
@@ -120,11 +101,9 @@ export default function IndexScreen() {
         await uploadBytes(storageRef, blob);
         audioUrl = await getDownloadURL(storageRef);
       }
-      await addDoc(collection(db, 'wishes'), {
+      await addWish({
         text: wish,
         category: category.trim().toLowerCase(),
-        likes: 0,
-        timestamp: serverTimestamp(),
         pushToken: pushToken || '',
         audioUrl,
       });
@@ -146,16 +125,13 @@ export default function IndexScreen() {
         return;
       }
 
-      const ref = doc(db, 'wishes', id);
-      await updateDoc(ref, {
-        likes: increment(1),
-      });
+      await likeWish(id);
 
       const updatedLikes = [...likedWishes, id];
       await AsyncStorage.setItem('likedWishes', JSON.stringify(updatedLikes));
 
-      const snap = await getDoc(ref);
-      const token = snap.data()?.pushToken;
+      const snap = await getWish(id);
+      const token = snap?.pushToken;
 
       if (token) {
         await fetch('https://exp.host/--/api/v2/push/send', {

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -1,7 +1,11 @@
 // app/(tabs)/profile/index.tsx — Enhanced Profile Screen with Analytics
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRouter } from 'expo-router';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import {
+  getWishesByNickname,
+  getAllWishes,
+  getWishComments,
+} from '../../../helpers/firestore';
 import React, { useEffect, useState } from 'react';
 import {
   Alert,
@@ -17,7 +21,6 @@ import {
   View,
 } from 'react-native';
 import { PieChart } from 'react-native-chart-kit';
-import { db } from '../../../firebase';
 
 export default function ProfileScreen() {
   const [nickname, setNickname] = useState('');
@@ -42,7 +45,7 @@ export default function ProfileScreen() {
       setNickname(stored);
       setInputName(stored);
 
-      const wishesSnap = await getDocs(query(collection(db, 'wishes'), where('nickname', '==', stored)));
+      const wishesData = await getWishesByNickname(stored);
       const wishes: any[] = [];
       let likeCount = 0;
       const wishDates: string[] = [];
@@ -50,9 +53,8 @@ export default function ProfileScreen() {
       let topWish = '';
       let topLikes = -1;
 
-      wishesSnap.docs.forEach(doc => {
-        const data = doc.data();
-        wishes.push({ ...data, id: doc.id });
+      wishesData.forEach((data) => {
+        wishes.push({ ...data, id: data.id });
         likeCount += data.likes || 0;
         if (data.timestamp?.toDate) {
           wishDates.push(data.timestamp.toDate().toDateString());
@@ -73,16 +75,14 @@ export default function ProfileScreen() {
       setStats({ totalLikes: likeCount, topWish, firstWish });
       setCategoryData(catData);
 
-      const allWishesSnap = await getDocs(collection(db, 'wishes'));
+      const allWishesData = await getAllWishes();
       const allComments: any[] = [];
 
-      for (const wishDoc of allWishesSnap.docs) {
-        const commentsRef = collection(db, 'wishes', wishDoc.id, 'comments');
-        const commentsSnap = await getDocs(commentsRef);
-        commentsSnap.forEach((doc) => {
-          const data = doc.data();
+      for (const wishDoc of allWishesData) {
+        const commentsSnap = await getWishComments(wishDoc.id);
+        commentsSnap.forEach((data) => {
           if (data.nickname === stored) {
-            allComments.push({ ...data, id: doc.id, wishId: wishDoc.id });
+            allComments.push({ ...data, id: data.id, wishId: wishDoc.id });
           }
         });
       }

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -1,15 +1,8 @@
 import { useRouter } from 'expo-router';
-import { collection, limit, onSnapshot, orderBy, query } from 'firebase/firestore';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, SafeAreaView, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { db } from '../firebase';
+import { listenTrendingWishes, Wish } from '../helpers/firestore';
 
-interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-}
 
 export default function TrendingScreen() {
   const router = useRouter();
@@ -17,13 +10,8 @@ export default function TrendingScreen() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const q = query(collection(db, 'wishes'), orderBy('likes', 'desc'), limit(20));
-    const unsubscribe = onSnapshot(q, (snapshot) => {
-      const data = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...(doc.data() as Omit<Wish, 'id'>),
-      }));
-      setWishes(data as Wish[]);
+    const unsubscribe = listenTrendingWishes((data) => {
+      setWishes(data);
       setLoading(false);
     });
     return () => unsubscribe();


### PR DESCRIPTION
## Summary
- add `helpers/firestore.ts` with common Firestore helpers
- refactor screens to use the new helpers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b5d8b704c8327b9872025caf28ffe