### PR TITLE
Centralize Wish type

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -20,14 +20,7 @@ import {
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { db } from '../../firebase';
-
-interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-  audioUrl?: string;
-}
+import type { Wish } from '../../types/Wish';
 
 const allCategories = ['love', 'health', 'career', 'general', 'money', 'friendship', 'fitness'];
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,15 +34,7 @@ import {
   View,
 } from 'react-native';
 import { db, storage } from '../../firebase';
-
-interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-  pushToken?: string;
-  audioUrl?: string;
-}
+import type { Wish } from '../../types/Wish';
 
 export default function IndexScreen() {
   const [wish, setWish] = useState('');

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -3,13 +3,7 @@ import { collection, limit, onSnapshot, orderBy, query } from 'firebase/firestor
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, SafeAreaView, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { db } from '../firebase';
-
-interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-}
+import type { Wish } from '../types/Wish';
 
 export default function TrendingScreen() {
   const router = useRouter();

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -28,14 +28,7 @@ import {
   View,
 } from 'react-native';
 import { db } from '../../firebase';
-
-interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-  audioUrl?: string;
-}
+import type { Wish } from '../../types/Wish';
 
 interface Comment {
   id: string;

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -1,0 +1,8 @@
+export interface Wish {
+  id: string;
+  text: string;
+  category: string;
+  likes: number;
+  pushToken?: string;
+  audioUrl?: string;
+}


### PR DESCRIPTION
## Summary
- add `types/Wish.ts` to define a shared `Wish` interface
- use that interface across explore, index, trending and wish screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b5d8cc4048327baa00ebe0627600f