### PR TITLE
Fix Firestore imports

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,20 +1,11 @@
 // app/(tabs)/explore.tsx — Visually Enhanced Explore Screen with Pull-to-Refresh
 import {
-import {
   listenTrendingWishes,
   listenWishes,
   Wish,
 } from '../../helpers/firestore';
 
-import {
-  addDoc,
-  collection,
-  limit,
-  onSnapshot,
-  orderBy,
-  query,
-  serverTimestamp,
-} from 'firebase/firestore';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 
 import React, { useEffect, useState } from 'react';
 import {


### PR DESCRIPTION
## Summary
- keep only used Firestore functions in `explore` screen

## Testing
- `npm run lint` *(fails: Parsing error and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685b702daadc8327b626b8031d81e328