### PR TITLE
Refactor Wish interface

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,9 +1,7 @@
 // app/(tabs)/explore.tsx — Visually Enhanced Explore Screen with Pull-to-Refresh
 import {
-import {
   listenTrendingWishes,
   listenWishes,
-  Wish,
 } from '../../helpers/firestore';
 
 import {
@@ -28,7 +26,7 @@ import {
     TouchableOpacity,
     View,
 } from 'react-native';
-import ReportDialog from '../components/ReportDialog';
+import ReportDialog from '../../components/ReportDialog';
 import { Picker } from '@react-native-picker/picker';
 import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
@@ -64,37 +62,25 @@ try {
 
   const fetchWishes = () => {
     setLoading(true);
-setLoading(true);
-const unsubscribe = (trendingMode ? listenTrendingWishes : listenWishes)((all: Wish[]) => {
-  const filtered = all.filter((wish) => {
-    const inCategory =
-      trendingMode || !selectedCategory || wish.category === selectedCategory;
-    const inSearch = wish.text.toLowerCase().includes(searchTerm.toLowerCase());
-    return inCategory && inSearch;
-  });
-  setFilteredWishes(filtered);
-  setLoading(false);
-});
-
-return unsubscribe;
-
-        const inCategory =
-          trendingMode || !selectedCategory || wish.category === selectedCategory;
-        const inSearch = wish.text.toLowerCase().includes(searchTerm.toLowerCase());
-        return inCategory && inSearch;
-      });
-      setFilteredWishes(filtered);
-      setLoading(false);
-    },
-    (err) => {
-      console.error('❌ Failed to load wishes:', err);
-      setError('Failed to load wishes');
-      setLoading(false);
-    }
-  );
-  return unsubscribe;
-};
-
+    const unsubscribe = (trendingMode ? listenTrendingWishes : listenWishes)(
+      (all: Wish[]) => {
+        const filtered = all.filter((wish) => {
+          const inCategory =
+            trendingMode || !selectedCategory || wish.category === selectedCategory;
+          const inSearch = wish.text
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase());
+          return inCategory && inSearch;
+        });
+        setFilteredWishes(filtered);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('❌ Failed to load wishes:', err);
+        setError('Failed to load wishes');
+        setLoading(false);
+      }
+    );
     return unsubscribe;
   };
 
@@ -131,32 +117,29 @@ return unsubscribe;
 
   const renderWish = ({ item }: { item: Wish }) => (
     <View style={styles.wishItem}>
-<View>
-  <Text style={styles.wishCategory}>
-    #{item.category} {item.audioUrl ? '🔊' : ''}
-  </Text>
-  <Text style={styles.wishText}>{item.text}</Text>
+      <Text style={styles.wishCategory}>
+        #{item.category} {item.audioUrl ? '🔊' : ''}
+      </Text>
+      <Text style={styles.wishText}>{item.text}</Text>
 
-  {item.isPoll ? (
-    <View style={{ marginTop: 6 }}>
-      <Text style={styles.pollText}>{item.optionA}: {item.votesA || 0}</Text>
-      <Text style={styles.pollText}>{item.optionB}: {item.votesB || 0}</Text>
-    </View>
-  ) : (
-    <Text style={styles.likes}>❤️ {item.likes}</Text>
-  )}
+      {item.isPoll ? (
+        <View style={{ marginTop: 6 }}>
+          <Text style={styles.pollText}>{item.optionA}: {item.votesA || 0}</Text>
+          <Text style={styles.pollText}>{item.optionB}: {item.votesB || 0}</Text>
+        </View>
+      ) : (
+        <Text style={styles.likes}>❤️ {item.likes}</Text>
+      )}
 
-  <TouchableOpacity
-    onPress={() => {
-      setReportTarget(item.id);
-      setReportVisible(true);
-    }}
-    style={{ marginTop: 4 }}
-  >
-    <Text style={{ color: '#f87171' }}>Report</Text>
-  </TouchableOpacity>
-</View>
-
+      <TouchableOpacity
+        onPress={() => {
+          setReportTarget(item.id);
+          setReportVisible(true);
+        }}
+        style={{ marginTop: 4 }}
+      >
+        <Text style={{ color: '#f87171' }}>Report</Text>
+      </TouchableOpacity>
     </View>
   );
 
@@ -357,8 +340,6 @@ const styles = StyleSheet.create({
     color: '#f87171',
     textAlign: 'center',
     marginTop: 20,
-  },
-
   },
   noResults: {
     color: '#ccc',

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -10,7 +10,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { listenTrendingWishes, Wish } from '../helpers/firestore';
+import { listenTrendingWishes } from '../helpers/firestore';
 import ReportDialog from '../components/ReportDialog';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore'; // Only include if still used
 import { db } from '../firebase';
@@ -73,7 +73,7 @@ try {
         ) : (
           <Text style={styles.likes}>❤️ {item.likes}</Text>
         )}
-      </View>
+      </TouchableOpacity>
 
       <TouchableOpacity
         onPress={() => {
@@ -84,7 +84,7 @@ try {
       >
         <Text style={{ color: '#f87171' }}>Report</Text>
       </TouchableOpacity>
-    </TouchableOpacity>
+    </View>
 
   );
 
@@ -164,7 +164,5 @@ const styles = StyleSheet.create({
     color: '#f87171',
     textAlign: 'center',
     marginTop: 20,
-  },
-
   },
 });

--- a/helpers/firestore.ts
+++ b/helpers/firestore.ts
@@ -1,15 +1,6 @@
 import { collection, query, orderBy, limit, onSnapshot, addDoc, doc, updateDoc, increment, getDoc, serverTimestamp, getDocs, where } from 'firebase/firestore';
 import { db } from '../firebase';
-
-export interface Wish {
-  id: string;
-  text: string;
-  category: string;
-  likes: number;
-  pushToken?: string;
-  audioUrl?: string;
-  [key: string]: any;
-}
+import type { Wish } from '../types/Wish';
 
 export interface Comment {
   id: string;

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -5,4 +5,10 @@ export interface Wish {
   likes: number;
   pushToken?: string;
   audioUrl?: string;
+  isPoll?: boolean;
+  optionA?: string;
+  optionB?: string;
+  votesA?: number;
+  votesB?: number;
+  [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- expand `types/Wish` to include poll and vote fields
- reference the shared `Wish` type in Firestore helpers
- fix imports of `Wish` in trending and explore screens
- clean up explore and trending screens to satisfy lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b7033bc048327b3f8538d377b76c9