### PR TITLE
Add Firebase Cloud Functions for push notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules/
+functions/node_modules/
 
 # Expo
 .expo/

--- a/README.md
+++ b/README.md
@@ -55,4 +55,7 @@ Join our community of developers creating universal apps.
 
 ## Push notifications
 
-The app registers a device for Expo push notifications. When someone likes or comments on one of your wishes, a notification is sent to the push token saved with that wish.
+The app registers a device for Expo push notifications. A Firebase Cloud
+Function in `functions/index.js` listens for Firestore updates and sends a
+notification whenever a wish gets a new like or comment. The push token saved
+with each wish is used so the creator receives the message automatically.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,57 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+const { Expo } = require('expo-server-sdk');
+
+admin.initializeApp();
+const db = admin.firestore();
+const expo = new Expo();
+
+exports.notifyWishLike = functions.firestore
+  .document('wishes/{wishId}')
+  .onUpdate(async (change, context) => {
+    const before = change.before.data();
+    const after = change.after.data();
+    if (after.likes > before.likes && after.pushToken) {
+      const token = after.pushToken;
+      if (!Expo.isExpoPushToken(token)) return null;
+      const messages = [
+        {
+          to: token,
+          sound: 'default',
+          title: 'Someone liked your wish! \u2764\ufe0f',
+          body: 'Your dream is spreading good vibes.',
+        },
+      ];
+      try {
+        await expo.sendPushNotificationsAsync(messages);
+      } catch (err) {
+        console.error('Error sending like notification', err);
+      }
+    }
+    return null;
+  });
+
+exports.notifyWishComment = functions.firestore
+  .document('wishes/{wishId}/comments/{commentId}')
+  .onCreate(async (snap, context) => {
+    const wishId = context.params.wishId;
+    const wishSnap = await db.collection('wishes').doc(wishId).get();
+    const wish = wishSnap.data();
+    if (!wish || !wish.pushToken) return null;
+    const token = wish.pushToken;
+    if (!Expo.isExpoPushToken(token)) return null;
+    const messages = [
+      {
+        to: token,
+        sound: 'default',
+        title: 'New comment on your wish \ud83d\udcac',
+        body: 'Someone left a comment on your wish.',
+      },
+    ];
+    try {
+      await expo.sendPushNotificationsAsync(messages);
+    } catch (err) {
+      console.error('Error sending comment notification', err);
+    }
+    return null;
+  });

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "whisplist-functions",
+  "version": "1.0.0",
+  "main": "index.js",
+  "engines": { "node": "18" },
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1",
+    "expo-server-sdk": "^4.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create `functions` directory with Cloud Functions
- trigger notifications when a wish receives a like or comment
- document the new Cloud Function setup in the README
- ignore `functions/node_modules` in git

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ca4a191308327a8a81621db916dde