### PR TITLE
Add wish boosting

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -65,7 +65,17 @@ useEffect(() => {
   registerForPushNotificationsAsync().then(setPushToken);
 
   const unsubscribe = listenWishes((w) => {
-    setWishList(w);
+    const now = new Date();
+    const boosted = w.filter(
+      (wish) => wish.boostedUntil && wish.boostedUntil.toDate && wish.boostedUntil.toDate() > now
+    );
+    boosted.sort((a, b) =>
+      b.boostedUntil.toDate().getTime() - a.boostedUntil.toDate().getTime()
+    );
+    const normal = w.filter(
+      (wish) => !wish.boostedUntil || !wish.boostedUntil.toDate || wish.boostedUntil.toDate() <= now
+    );
+    setWishList([...boosted, ...normal]);
     setLoading(false);
   });
 
@@ -373,6 +383,10 @@ useEffect(() => {
     ) : (
       <Text style={styles.likeText}>❤️ {item.likes}</Text>
     )}
+    {item.boostedUntil && item.boostedUntil.toDate &&
+      item.boostedUntil.toDate() > new Date() && (
+        <Text style={styles.boostedLabel}>🚀 Boosted</Text>
+      )}
   </TouchableOpacity>
 
   <TouchableOpacity
@@ -482,6 +496,11 @@ const styles = StyleSheet.create({
     color: '#a78bfa',
     marginTop: 6,
     fontSize: 14,
+  },
+  boostedLabel: {
+    color: '#facc15',
+    fontSize: 12,
+    marginTop: 4,
   },
   pollText: {
     color: '#fff',

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -9,6 +9,7 @@ import {
   listenWishComments,
   addComment,
   updateCommentReaction,
+  boostWish,
 } from '../../helpers/firestore';
 
 import {
@@ -258,6 +259,17 @@ try {
     }
   }, [fulfillment, id]);
 
+  const handleBoostWish = useCallback(async () => {
+    if (!wish) return;
+    try {
+      // Payment flow would occur here
+      await boostWish(wish.id, 24);
+      await fetchWish();
+    } catch (err) {
+      console.error('❌ Failed to boost wish:', err);
+    }
+  }, [fetchWish, wish]);
+
 
   const renderCommentItem = useCallback(
     (item: Comment, level = 0) => {
@@ -407,6 +419,10 @@ try {
             <Text style={{ color: '#a78bfa' }}>▶ Play Audio</Text>
           </TouchableOpacity>
         )}
+
+        <TouchableOpacity onPress={handleBoostWish} style={{ marginTop: 8 }}>
+          <Text style={{ color: '#facc15' }}>Boost Wish</Text>
+        </TouchableOpacity>
 
         <TouchableOpacity
           onPress={() => {

--- a/helpers/firestore.ts
+++ b/helpers/firestore.ts
@@ -42,6 +42,12 @@ export async function likeWish(id: string) {
   return updateDoc(ref, { likes: increment(1) });
 }
 
+export async function boostWish(id: string, hours: number) {
+  const ref = doc(db, 'wishes', id);
+  const boostedUntil = new Date(Date.now() + hours * 60 * 60 * 1000);
+  return updateDoc(ref, { boostedUntil });
+}
+
 export async function getWish(id: string): Promise<Wish | null> {
   const snap = await getDoc(doc(db, 'wishes', id));
   return snap.exists() ? ({ id: snap.id, ...(snap.data() as Omit<Wish,'id'>) } as Wish) : null;
@@ -100,6 +106,7 @@ export async function getWishesByNickname(nickname: string): Promise<Wish[]> {
       text: data.text,
       category: data.category,
       likes: data.likes,
+      boostedUntil: data.boostedUntil,
       pushToken: data.pushToken,
       audioUrl: data.audioUrl,
       imageUrl: data.imageUrl,
@@ -122,6 +129,7 @@ export async function getAllWishes(): Promise<Wish[]> {
       text: data.text,
       category: data.category,
       likes: data.likes,
+      boostedUntil: data.boostedUntil,
       pushToken: data.pushToken,
       audioUrl: data.audioUrl,
       imageUrl: data.imageUrl,

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -3,6 +3,7 @@ export interface Wish {
   text: string;
   category: string;
   likes: number;
+  boostedUntil?: any;
   pushToken?: string;
   audioUrl?: string;
   imageUrl?: string;


### PR DESCRIPTION
## Summary
- allow wishes to store `boostedUntil`
- expose a `boostWish` helper
- show boosted wishes at the top of the list
- display a badge for boosted wishes
- add Boost Wish button in wish details

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ca579eda0832785136988383c7252