### PR TITLE
Fix AuthContext imports and typings

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,4 +1,12 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as React from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+  type ReactElement,
+} from 'react';
 import {
   onAuthStateChanged,
   signInWithEmailAndPassword,
@@ -54,7 +62,7 @@ const AuthContext = createContext<AuthContextValue>({
   pickImage: async () => undefined,
 });
 
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const AuthProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- fix React imports and types in `AuthContext`

## Testing
- `npx tsc -p tsconfig.json --noEmit --pretty false`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685da785a9bc832787eb9d3caa1827c3