### PR TITLE
Add fallback 404 screen

### DIFF
--- a/app/404.tsx
+++ b/app/404.tsx
@@ -1,0 +1,1 @@
+export { default } from './+not-found';


### PR DESCRIPTION
## Summary
- add a simple `app/404.tsx` that re-exports the existing not-found screen
- confirm tabs layout registers the main screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685db1b0e0888327a94618fcc8c554bc