### PR TITLE
Add metro config for alias and CJS support

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,16 @@
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+// Ensure Hermes can load CJS modules like firebase
+config.resolver.sourceExts.push('cjs');
+
+// Support TypeScript paths such as "@/*" defined in tsconfig.json
+config.resolver.alias = {
+  ...config.resolver.alias,
+  '@': path.resolve(__dirname),
+};
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add `metro.config.js` to support TypeScript path alias and CommonJS modules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e0f5def388327a2ac06750f08cd7e