### PR TITLE
Fix expo-router screen registration

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect, Slot } from 'expo-router';
+import { Redirect, Stack } from 'expo-router';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { AppContainer } from '@/components/AppContainer';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
@@ -8,7 +8,7 @@ function LayoutInner() {
   const { user, loading } = useAuth();
   if (loading) return null;
   if (!user) return <Redirect href="/auth" />;
-  return <Slot />;
+  return <Stack screenOptions={{ headerShown: false }} />;
 }
 
 export default function RootLayout() {


### PR DESCRIPTION
## Summary
- ensure root layout registers app routes with `<Stack />`

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685e10ccd66c8327b2f03ca11c4e3a40