### PR TITLE
Disable auth check for dev testing

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Redirect, Stack } from 'expo-router';
+import { Stack } from 'expo-router';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { AppContainer } from '@/components/AppContainer';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 
 function LayoutInner() {
-  const { user, loading } = useAuth();
+  const { loading } = useAuth();
   if (loading) return null;
-  if (!user) return <Redirect href="/auth" />;
+  // Auth requirement temporarily disabled for development
   return <Stack screenOptions={{ headerShown: false }} />;
 }
 


### PR DESCRIPTION
## Summary
- remove redirect to `/auth`
- stop importing `Redirect`
- note that auth is disabled for now

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e15e624688327880021e3d2e50427