### PR TITLE
Temporarily bypass auth during dev

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,9 +5,9 @@ import { Stack } from 'expo-router';
 import React from 'react';
 
 function LayoutInner() {
-  const { loading } = useAuth();
+  const { user, loading } = useAuth();
   if (loading) return null;
-  // Auth requirement temporarily disabled for development
+  // if (!user) return <Redirect href="/auth" />;
   return <Stack screenOptions={{ headerShown: false }} />;
 }
 

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -108,6 +108,23 @@ export const AuthProvider = ({ children }: { children: ReactNode }): ReactElemen
     return unsub;
   }, []);
 
+  // Temporary development bypass
+  useEffect(() => {
+    if (__DEV__ && !user && !loading) {
+      const fakeUser = {
+        uid: 'dev',
+        email: 'dev@test.com',
+        displayName: 'DevUser',
+      } as User;
+      setUser(fakeUser);
+      setProfile({
+        displayName: 'DevUser',
+        email: 'dev@test.com',
+        isAnonymous: false,
+      });
+    }
+  }, [user, loading]);
+
   const signUp = async (email: string, password: string) => {
     await createUserWithEmailAndPassword(auth, email, password);
   };


### PR DESCRIPTION
## Summary
- comment out auth redirect in `_layout.tsx`
- add a development-only effect that injects a fake user in `AuthContext`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e7c60834c8327a3cbf819c8b5c85e