### PR TITLE
Fix expo-router export names

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,7 +3,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from 'expo-router';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
-export default function TabLayout() {
+export default function Layout() {
   const colorScheme = useColorScheme();
 
   return (

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -23,7 +23,7 @@ import type { Wish } from '../../types/Wish';
 
 const allCategories = ['love', 'health', 'career', 'general', 'money', 'friendship', 'fitness'];
 
-export default function ExploreScreen() {
+export default function Page() {
   const router = useRouter();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [filteredWishes, setFilteredWishes] = useState<Wish[]>([]);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -42,7 +42,7 @@ import type { Wish } from '../../types/Wish';
 import { useAuth } from '@/contexts/AuthContext';
 
 
-export default function IndexScreen() {
+export default function Page() {
   const [wish, setWish] = useState('');
   const [category, setCategory] = useState('general');
   const [wishList, setWishList] = useState<Wish[]>([]);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Image } from 'react-native';
 import { useAuth } from '@/contexts/AuthContext';
 
-export default function ProfileScreen() {
+export default function Page() {
   const { user, profile, updateProfile, pickImage, signOut } = useAuth();
   const [displayName, setDisplayName] = useState(profile?.displayName || '');
   const [bio, setBio] = useState(profile?.bio || '');

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -27,7 +27,7 @@ import {
   getWishesByNickname,
 } from '../../helpers/firestore';
 
-export default function SettingsScreen() {
+export default function Page() {
   const { theme, toggleTheme } = useTheme();
 
   interface User {

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,6 +1,6 @@
 import { Text, View } from 'react-native';
 
-export default function NotFound() {
+export default function Page() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text>404 - Not Found</Text>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,7 +11,7 @@ function LayoutInner() {
   return <Stack screenOptions={{ headerShown: false }} />;
 }
 
-export default function RootLayout() {
+export default function Layout() {
   return (
     <AuthProvider>
       <ThemeProvider>

--- a/app/auth/index.tsx
+++ b/app/auth/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
-export default function AuthScreen() {
+export default function Page() {
   const router = useRouter();
   const { signIn, signUp, signInWithGoogle, signInAnonymously } = useAuth();
   const [email, setEmail] = useState('');

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -21,7 +21,7 @@ import type { Wish } from '../types/Wish';
 import { Colors } from '../constants/Colors';
 
 
-export default function TrendingScreen() {
+export default function Page() {
   const [wishes, setWishes] = useState<Wish[]>([]);
   const [loading, setLoading] = useState(true);
   const [reportVisible, setReportVisible] = useState(false);

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -66,7 +66,7 @@ const emojiOptions = ['❤️', '😂', '😢', '👍'];
 // Approximate height of a single comment item including margins
 const COMMENT_ITEM_HEIGHT = 80;
 
-export default function WishDetailScreen() {
+export default function Page() {
   const { id } = useLocalSearchParams();
   const router = useRouter();
   const colorScheme = useColorScheme();


### PR DESCRIPTION
## Summary
- rename exported components to `Page`

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685e7df8fac08327b5715985b9d95ba7