### PR TITLE
Fix Expo start error - add Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
+  };
+};


### PR DESCRIPTION
## Summary
- add missing `babel.config.js` required by Expo Router

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm start` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e81eca0908327bef429e759eef55e