### PR TITLE
Fix Expo router component registration

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,16 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['expo-router/babel'],
+    plugins: [
+      'expo-router/babel',
+      [
+        'module-resolver',
+        {
+          alias: {
+            '@': './',
+          },
+        },
+      ],
+    ],
   };
 };


### PR DESCRIPTION
## Summary
- configure `babel-plugin-module-resolver` with the `@` alias

This allows Metro and Expo Router to properly resolve path aliases used across the project.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e8f4290d48327800bd76411805d3c