### PR TITLE
Resolve lint warnings

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,5 +1,5 @@
 // app/(tabs)/explore.tsx — Visually Enhanced Explore Screen with Pull-to-Refresh
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -42,7 +42,7 @@ export default function Page() {
     return unsubscribe;
   }, []);
 
-  const fetchWishes = () => {
+  const fetchWishes = useCallback(() => {
     setLoading(true);
     try {
       const source = trendingMode ? listenTrendingWishes : listenWishes;
@@ -69,12 +69,12 @@ export default function Page() {
       setLoading(false);
       return () => {};
     }
-  };
+  }, [trendingMode, selectedCategory, searchTerm]);
 
   useEffect(() => {
     const unsubscribe = fetchWishes();
     return () => unsubscribe();
-  }, [selectedCategory, trendingMode, searchTerm]);
+  }, [fetchWishes]);
 
   const handleReload = () => {
     fetchWishes();

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,11 +11,8 @@ import {
 import {
   listenWishes,
   addWish,
-  likeWish,
-  getWish,
 } from '../../helpers/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
-// eslint-disable-next-line import/no-unresolved
 import * as ImagePicker from 'expo-image-picker';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import React, { useEffect, useState } from 'react';
@@ -47,7 +44,6 @@ export default function Page() {
   const [category, setCategory] = useState('general');
   const [wishList, setWishList] = useState<Wish[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [pushToken, setPushToken] = useState<string | null>(null);
   const [reportVisible, setReportVisible] = useState(false);
@@ -217,42 +213,6 @@ useEffect(() => {
     }
   };
 
-  const handleLike = async (id: string) => {
-    try {
-      const liked = await AsyncStorage.getItem('likedWishes');
-      const likedWishes = liked ? JSON.parse(liked) : [];
-
-      if (likedWishes.includes(id)) {
-        console.log('⛔ Already liked');
-        return;
-      }
-
-      await likeWish(id);
-
-      const updatedLikes = [...likedWishes, id];
-      await AsyncStorage.setItem('likedWishes', JSON.stringify(updatedLikes));
-
-      const snap = await getWish(id);
-      const token = snap?.pushToken;
-
-      if (token) {
-        await fetch('https://exp.host/--/api/v2/push/send', {
-          method: 'POST',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            to: token,
-            title: 'Someone liked your wish! ❤️',
-            body: 'Your dream is spreading good vibes.',
-          }),
-        });
-      }
-    } catch (error) {
-      console.error('❌ Failed to like wish:', error);
-    }
-  };
 
   const handleReport = async (reason: string) => {
     if (!reportTarget) return;
@@ -413,8 +373,6 @@ useEffect(() => {
 
         {loading ? (
           <ActivityIndicator size="large" color="#a78bfa" style={{ marginTop: 20 }} />
-        ) : error ? (
-          <Text style={styles.errorText}>{error}</Text>
         ) : filteredWishes.length === 0 ? (
           <Text style={styles.noResults}>No matching wishes 💭</Text>
         ) : (
@@ -574,11 +532,6 @@ const styles = StyleSheet.create({
     color: '#ccc',
     fontSize: 12,
     marginBottom: 2,
-  },
-  errorText: {
-    color: '#f87171',
-    textAlign: 'center',
-    marginTop: 20,
   },
   noResults: {
     color: '#ccc',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,7 +5,7 @@ import { Stack } from 'expo-router';
 import React from 'react';
 
 function LayoutInner() {
-  const { user, loading } = useAuth();
+  const { loading } = useAuth();
   if (loading) return null;
   // if (!user) return <Redirect href="/auth" />;
   return <Stack screenOptions={{ headerShown: false }} />;

--- a/app/trending.tsx
+++ b/app/trending.tsx
@@ -26,7 +26,6 @@ export default function Page() {
   const [loading, setLoading] = useState(true);
   const [reportVisible, setReportVisible] = useState(false);
   const [reportTarget, setReportTarget] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const colorScheme = useColorScheme();
   const navigation = useNavigation();
@@ -151,10 +150,6 @@ const WishCard: React.FC<{ item: Wish }> = ({ item }) => {
             color="#a78bfa"
             style={{ marginTop: 20 }}
           />
-        ) : error ? (
-          <Text style={[styles.errorText, { color: Colors[colorScheme].tint }]}>
-            {error}
-          </Text>
         ) : (
           <FlatList
             data={wishes}
@@ -228,9 +223,5 @@ const styles = StyleSheet.create({
   },
   pollText: {
     fontSize: 14,
-  },
-  errorText: {
-    textAlign: 'center',
-    marginTop: 20,
   },
 });

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -39,10 +39,10 @@ import {
   View,
   Dimensions,
   Alert,
+  Linking,
 } from 'react-native';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { BarChart } from 'react-native-chart-kit';
-import { Linking } from 'react-native';
 import ReportDialog from '../../components/ReportDialog';
 import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
@@ -65,6 +65,7 @@ interface Comment {
 const emojiOptions = ['❤️', '😂', '😢', '👍'];
 // Approximate height of a single comment item including margins
 const COMMENT_ITEM_HEIGHT = 80;
+const HIT_SLOP = { top: 10, bottom: 10, left: 10, right: 10 };
 
 export default function Page() {
   const { id } = useLocalSearchParams();
@@ -84,7 +85,6 @@ export default function Page() {
   const [postingComment, setPostingComment] = useState(false);
   const [useProfileComment, setUseProfileComment] = useState(true);
   const { user, profile } = useAuth();
-  const HIT_SLOP = { top: 10, bottom: 10, left: 10, right: 10 };
 
   const flatListRef = useRef<FlatList<Comment>>(null);
 


### PR DESCRIPTION
## Summary
- clean up unused variables in home, trending, layout
- consolidate react-native imports for the wish page
- make explore `fetchWishes` a `useCallback`
- remove unused error handling UI
- store `HIT_SLOP` outside the component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f092ea6b083279b0923ce2189f5e6