### PR TITLE
Fix useCallback import

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Join our community of developers creating universal apps.
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
 
+## Audio support
+
+`expo-av` has been deprecated in favor of the new [`expo-audio`](https://docs.expo.dev/versions/latest/sdk/audio/) library.
+When you upgrade, replace `expo-av` imports with `expo-audio` and adjust any API
+changes (mainly how sound and recording objects are created). The rest of the
+logic in this repo can remain largely the same.
+
 ## Push notifications
 
 The app registers the device for Expo push notifications on first launch.

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,7 +13,7 @@ import {
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';
 import { addDoc, collection, serverTimestamp, getDocs, query, orderBy, doc, getDoc } from 'firebase/firestore';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   ActivityIndicator,
   Alert,


### PR DESCRIPTION
## Summary
- fix missing `useCallback` import in home screen
- document `expo-audio` as the future replacement for `expo-av`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c70b2c1d083279f170b1a62bee743