### PR TITLE
Fix ScrollView wrapping for major screens

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -14,6 +14,7 @@ import {
   RefreshControl,
   KeyboardAvoidingView,
   Platform,
+  ScrollView,
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { useRouter } from 'expo-router';
@@ -172,7 +173,8 @@ export default function Page() {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={styles.container}
       >
-        <Text style={styles.title}>Explore Wishes 🧭</Text>
+        <ScrollView contentContainerStyle={styles.contentContainer}>
+          <Text style={styles.title}>Explore Wishes 🧭</Text>
 
         <TextInput
           style={styles.searchInput}
@@ -244,6 +246,7 @@ export default function Page() {
             contentContainerStyle={{ paddingBottom: 80, flexGrow: 1 }}
           />
         )}
+        </ScrollView>
         <ReportDialog
           visible={reportVisible}
           onClose={() => {
@@ -264,7 +267,11 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
+  },
+  contentContainer: {
     padding: 20,
+    paddingBottom: 100,
+    flexGrow: 1,
   },
   title: {
     color: '#fff',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,6 +34,7 @@ import {
   View,
   RefreshControl,
   Animated,
+  ScrollView,
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import ReportDialog from '../../components/ReportDialog';
@@ -349,8 +350,9 @@ useEffect(() => {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={styles.container}
       >
-        <Text style={styles.title}>WhispList ✨</Text>
-        <Text style={styles.subtitle}>Post a wish and see what dreams grow 🌱</Text>
+        <ScrollView contentContainerStyle={styles.contentContainer}>
+          <Text style={styles.title}>WhispList ✨</Text>
+          <Text style={styles.subtitle}>Post a wish and see what dreams grow 🌱</Text>
         {streakCount > 0 && (
           <Text style={styles.streak}>
             🔥 You’ve posted {streakCount} days in a row!
@@ -557,6 +559,7 @@ useEffect(() => {
             )}
           />
         )}
+        </ScrollView>
         <ReportDialog
           visible={reportVisible}
           onClose={() => {
@@ -577,7 +580,11 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
+  },
+  contentContainer: {
     padding: 20,
+    paddingBottom: 100,
+    flexGrow: 1,
   },
   title: {
     fontSize: 28,

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -46,6 +46,7 @@ import {
   Alert,
   Linking,
   RefreshControl,
+  ScrollView,
 } from 'react-native';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { BarChart } from 'react-native-chart-kit';
@@ -438,6 +439,7 @@ try {
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={80}
       >
+        <ScrollView contentContainerStyle={styles.contentContainer}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton} hitSlop={HIT_SLOP}>
           <Text style={[styles.backButtonText, { color: Colors[colorScheme].tint }]}>← Back</Text>
         </TouchableOpacity>
@@ -566,6 +568,7 @@ try {
   renderItem={renderComment}
   refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
   contentContainerStyle={{ paddingBottom: 80, flexGrow: 1 }}
+  scrollEnabled={false}
   initialNumToRender={10}
   getItemLayout={(_, index) => ({
     length: COMMENT_ITEM_HEIGHT,
@@ -628,7 +631,7 @@ try {
           onSubmit={handleReport}
         />
 
-        <Text style={styles.label}>Fulfillment</Text>
+<Text style={styles.label}>Fulfillment</Text>
         <TextInput
           style={styles.input}
           placeholder="Fulfillment text or link"
@@ -640,6 +643,7 @@ try {
         <TouchableOpacity style={styles.button} onPress={handleFulfillWish} hitSlop={HIT_SLOP}>
           <Text style={styles.buttonText}>Fulfill Wish</Text>
         </TouchableOpacity>
+        </ScrollView>
 
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -652,7 +656,11 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
+  },
+  contentContainer: {
     padding: 20,
+    paddingBottom: 100,
+    flexGrow: 1,
   },
   backButton: {
     marginBottom: 10,


### PR DESCRIPTION
## Summary
- wrap home, explore and detail screens in `ScrollView`
- place `KeyboardAvoidingView` outside scroll container
- add `contentContainer` style for scrolling area

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d167da7108327b7ed9361d4c018f3