### PR TITLE
Limit normal wish visibility to followers

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,6 +11,7 @@ import * as Audio from 'expo-audio';
 import {
   listenWishes,
   addWish,
+  getFollowingIds,
 } from '../../helpers/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';
@@ -84,23 +85,13 @@ export default function Page() {
 
 
 useEffect(() => {
-  const unsubscribe = listenWishes((w) => {
-    const now = new Date();
-    const boosted = w.filter(
-      (wish) => wish.boostedUntil && wish.boostedUntil.toDate && wish.boostedUntil.toDate() > now
-    );
-    boosted.sort((a, b) =>
-      b.boostedUntil.toDate().getTime() - a.boostedUntil.toDate().getTime()
-    );
-    const normal = w.filter(
-      (wish) => !wish.boostedUntil || !wish.boostedUntil.toDate || wish.boostedUntil.toDate() <= now
-    );
-    setWishList([...boosted, ...normal]);
+  const unsubscribe = listenWishes(user?.uid ?? null, (w) => {
+    setWishList(w);
     setLoading(false);
   });
 
   return () => unsubscribe();
-}, []);
+}, [user]);
 
 useEffect(() => {
   const fetchStatus = async () => {
@@ -318,25 +309,36 @@ useEffect(() => {
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      const snap = await getDocs(query(collection(db, 'wishes'), orderBy('timestamp', 'desc')));
-      const w = snap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Wish, 'id'>) })) as Wish[];
+      const followingIds = user ? await getFollowingIds(user.uid) : [];
+
       const now = new Date();
-      const boosted = w.filter(
-        (wish) => wish.boostedUntil && wish.boostedUntil.toDate && wish.boostedUntil.toDate() > now
+      const boostedSnap = await getDocs(
+        query(
+          collection(db, 'wishes'),
+          where('boostedUntil', '>', now),
+          orderBy('boostedUntil', 'desc')
+        )
       );
-      boosted.sort(
-        (a, b) => b.boostedUntil!.toDate().getTime() - a.boostedUntil!.toDate().getTime()
-      );
-      const normal = w.filter(
-        (wish) => !wish.boostedUntil || !wish.boostedUntil.toDate || wish.boostedUntil.toDate() <= now
-      );
+      const boosted = boostedSnap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Wish, 'id'>) })) as Wish[];
+
+      let normal: Wish[] = [];
+      if (user && followingIds.length) {
+        const normalSnap = await getDocs(
+          query(
+            collection(db, 'wishes'),
+            where('userId', 'in', followingIds),
+            orderBy('timestamp', 'desc')
+          )
+        );
+        normal = normalSnap.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<Wish, 'id'>) })) as Wish[];
+      }
       setWishList([...boosted, ...normal]);
     } catch (err) {
       console.error('❌ Failed to refresh wishes:', err);
     } finally {
       setRefreshing(false);
     }
-  }, []);
+  }, [user]);
 
   const filteredWishes = wishList.filter((wish) =>
     wish.text.toLowerCase().includes(searchTerm.toLowerCase())

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,21 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isBoosted() {
+      return resource.data.boostedUntil > request.time;
+    }
+    function isFollowerOf(userId) {
+      return request.auth != null &&
+        exists(/databases/$(database)/documents/users/$(userId)/followers/$(request.auth.uid));
+    }
+
+    match /wishes/{wishId} {
+      allow read: if isBoosted() || isFollowerOf(resource.data.userId);
+      allow write: if request.auth != null;
+    }
+
+    match /users/{userId}/followers/{followerId} {
+      allow read, write: if request.auth != null && request.auth.uid == followerId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- store followers per user and expose follow helpers
- filter wish queries by followed users
- show all boosted wishes but restrict normal wishes
- secure wish reads with new Firestore rules

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d504d40548327b34f41ab5680f0f6