### PR TITLE
Fix missing Firestore import

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -23,7 +23,7 @@ import {
   listenWishes,
   getFollowingIds,
 } from '../../helpers/firestore';
-import { addDoc, collection, serverTimestamp, getDocs, query, orderBy, limit } from 'firebase/firestore';
+import { addDoc, collection, serverTimestamp, getDocs, query, orderBy, where, limit } from 'firebase/firestore';
 import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
 import { useAuth } from '@/contexts/AuthContext';

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../helpers/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';
-import { addDoc, collection, serverTimestamp, getDocs, query, orderBy, doc, getDoc } from 'firebase/firestore';
+import { addDoc, collection, serverTimestamp, getDocs, query, orderBy, where, doc, getDoc } from 'firebase/firestore';
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import {
   ActivityIndicator,


### PR DESCRIPTION
## Summary
- add `where` to Firestore imports in `index.tsx` and `explore.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d548868ac8327aa25d517b7f1e121