### PR TITLE
Implement following system and filtered feed

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,5 +17,9 @@ service cloud.firestore {
     match /users/{userId}/followers/{followerId} {
       allow read, write: if request.auth != null && request.auth.uid == followerId;
     }
+
+    match /users/{userId}/following/{targetUserId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement follower/following subcollections
- update security rules for following docs
- add follow/unfollow on profile screen
- display follow/unfollow on wishes in feed
- filter wishes using following ids

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d581bf0dc8327bb0160a23b5034d1