### PR TITLE
Fix follow buttons when user ID missing

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -584,12 +584,15 @@ useEffect(() => {
               {user && item.userId && user.uid !== item.userId && (
                 <TouchableOpacity
                   onPress={async () => {
+                    if (!user?.uid) return;
+                    if (!item.userId) return;
+
                     if (followStatus[item.userId]) {
-                      await unfollowUser(user.uid, item.userId!);
-                      setFollowStatus((prev) => ({ ...prev, [item.userId!]: false }));
+                      await unfollowUser(user.uid, item.userId);
+                      setFollowStatus((prev) => ({ ...prev, [item.userId]: false }));
                     } else {
-                      await followUser(user.uid, item.userId!);
-                      setFollowStatus((prev) => ({ ...prev, [item.userId!]: true }));
+                      await followUser(user.uid, item.userId);
+                      setFollowStatus((prev) => ({ ...prev, [item.userId]: true }));
                     }
                   }}
                   style={{ marginTop: 4 }}


### PR DESCRIPTION
## Summary
- check `user.uid` before follow/unfollow logic
- exit early if user or wish `userId` is undefined

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d771e9fc483279e1a95dffbaf7712