### PR TITLE
Fix computed key error in follow toggle

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -587,12 +587,14 @@ useEffect(() => {
                     if (!user?.uid) return;
                     if (!item.userId) return;
 
-                    if (followStatus[item.userId]) {
-                      await unfollowUser(user.uid, item.userId);
-                      setFollowStatus((prev) => ({ ...prev, [item.userId]: false }));
+                    const targetId = item.userId;
+
+                    if (followStatus[targetId]) {
+                      await unfollowUser(user.uid, targetId);
+                      setFollowStatus((prev) => ({ ...prev, [targetId]: false }));
                     } else {
-                      await followUser(user.uid, item.userId);
-                      setFollowStatus((prev) => ({ ...prev, [item.userId]: true }));
+                      await followUser(user.uid, targetId);
+                      setFollowStatus((prev) => ({ ...prev, [targetId]: true }));
                     }
                   }}
                   style={{ marginTop: 4 }}


### PR DESCRIPTION
## Summary
- guard `item.userId` before using as computed key in follow toggle

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json` *(fails: other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d784447e883279aa4fdd7818ba1e4