### PR TITLE
Fix boosted wishes status guard

### DIFF
--- a/app/(tabs)/boosted.tsx
+++ b/app/(tabs)/boosted.tsx
@@ -48,14 +48,22 @@ export default function Page() {
 
   useEffect(() => {
     const fetchStatus = async () => {
-      const ids = Array.from(new Set(wishes.map((w) => w.userId).filter(Boolean)));
+      const ids = Array.from(
+        new Set(
+          wishes
+            .map((w) => w.userId)
+            .filter((id): id is string => typeof id === 'string')
+        )
+      );
       await Promise.all(
         ids.map(async (id) => {
           if (publicStatus[id] === undefined) {
             const snap = await getDoc(doc(db, 'users', id));
             setPublicStatus((prev) => ({
               ...prev,
-              [id]: snap.exists() ? snap.data().publicProfileEnabled !== false : false,
+              [id]: snap.exists()
+                ? snap.data().publicProfileEnabled !== false
+                : false,
             }));
           }
         })


### PR DESCRIPTION
## Summary
- filter undefined user ids in boosted wishes page

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: error TS2538 etc. in other files)*

------
https://chatgpt.com/codex/tasks/task_e_686d79dda480832787710ba4c2aa4a1b