### PR TITLE
Enhance boosted wish display

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -15,6 +15,7 @@ import {
   followUser,
   unfollowUser,
 } from '../../helpers/firestore';
+import { formatTimeLeft } from '../../helpers/time';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';
 import { addDoc, collection, serverTimestamp, getDocs, query, orderBy, where, doc, getDoc } from 'firebase/firestore';
@@ -564,8 +565,26 @@ useEffect(() => {
               <Text style={styles.noResults}>No matching wishes 💭</Text>
             )
           }
-          renderItem={({ item }) => (
-            <View style={[styles.wishItem, { backgroundColor: typeInfo[item.type || 'wish'].color }]}>
+          renderItem={({ item }) => {
+            const isBoosted =
+              item.boostedUntil &&
+              item.boostedUntil.toDate &&
+              item.boostedUntil.toDate() > new Date();
+            const timeLeft = isBoosted
+              ? formatTimeLeft(item.boostedUntil.toDate())
+              : '';
+
+            return (
+            <View
+              style={[
+                styles.wishItem,
+                {
+                  backgroundColor: typeInfo[item.type || 'wish'].color,
+                  borderColor: isBoosted ? '#facc15' : 'transparent',
+                  borderWidth: isBoosted ? 2 : 0,
+                },
+              ]}
+            >
               <TouchableOpacity onPress={() => router.push(`/wish/${item.id}`)} hitSlop={HIT_SLOP}>
                 {!item.isAnonymous &&
                   item.displayName &&
@@ -592,9 +611,10 @@ useEffect(() => {
                 ) : (
                   <Text style={styles.likeText}>❤️ {item.likes}</Text>
                 )}
-                {item.boostedUntil && item.boostedUntil.toDate &&
-                  item.boostedUntil.toDate() > new Date() && (
-                    <Text style={styles.boostedLabel}>🚀 Boosted</Text>
+                {isBoosted && (
+                    <Text style={styles.boostedLabel}>
+                      🚀 Boosted{timeLeft ? ` (${timeLeft})` : ''}
+                    </Text>
                   )}
               </TouchableOpacity>
 
@@ -634,7 +654,8 @@ useEffect(() => {
                 <Text style={{ color: '#f87171' }}>Report</Text>
               </TouchableOpacity>
             </View>
-          )}
+          );
+        }}
         />
         <ReportDialog
           visible={reportVisible}

--- a/helpers/time.ts
+++ b/helpers/time.ts
@@ -1,0 +1,9 @@
+export function formatTimeLeft(end: Date): string {
+  const diff = end.getTime() - Date.now();
+  if (diff <= 0) {
+    return '';
+  }
+  const hrs = Math.floor(diff / 3600000);
+  const mins = Math.floor((diff % 3600000) / 60000);
+  return `${hrs}h ${mins}m left`;
+}


### PR DESCRIPTION
## Summary
- add helper to format boosted time remaining
- highlight boosted wishes and show time left
- add boosted time display on home feed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d97c5b6f48327991b1b9ed5686a06