### PR TITLE
Add theme picker

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -220,6 +220,15 @@ export default function Page() {
           <ThemeSwatch key={t} name={t} />
         ))}
       </ScrollView>
+      <Picker
+        selectedValue={theme.name}
+        onValueChange={(value) => setTheme(value as ThemeName)}
+        style={[styles.picker, { backgroundColor: theme.input, color: theme.text }]}
+      >
+        {themeOptions.map((t) => (
+          <Picker.Item key={t} label={t} value={t} />
+        ))}
+      </Picker>
 
       <View style={styles.row}>
         <ThemedText style={styles.label}>Anonymize Username</ThemedText>


### PR DESCRIPTION
## Summary
- add a theme picker in settings to make changing themes easier

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: TS errors in trending.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_686dccc8924883278d0aa5821721040b