### PR TITLE
Add fulfillment link feature

### DIFF
--- a/components/FulfillmentLinkDialog.tsx
+++ b/components/FulfillmentLinkDialog.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, TextInput, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Colors } from '@/constants/Colors';
+
+interface FulfillmentLinkDialogProps {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (link: string) => void;
+  existingLink?: string;
+}
+
+export default function FulfillmentLinkDialog({ visible, onClose, onSubmit, existingLink }: FulfillmentLinkDialogProps) {
+  const [link, setLink] = useState('');
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
+
+  useEffect(() => {
+    if (visible) {
+      setLink(existingLink || '');
+    }
+  }, [visible, existingLink]);
+
+  const handleSubmit = () => {
+    onSubmit(link.trim());
+    setLink('');
+  };
+
+  return (
+    <Modal transparent visible={visible} animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.box}>
+          <TextInput
+            style={styles.input}
+            placeholder="Paste fulfillment link"
+            placeholderTextColor="#888"
+            value={link}
+            onChangeText={setLink}
+          />
+          <View style={styles.buttons}>
+            <TouchableOpacity onPress={onClose} style={[styles.button, styles.cancel]} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+              <Text style={styles.buttonText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleSubmit} style={styles.button} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+              <Text style={styles.buttonText}>Save</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const createStyles = (c: (typeof Colors)['light']) =>
+  StyleSheet.create({
+    overlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.6)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    box: {
+      width: '80%',
+      backgroundColor: c.background,
+      padding: 20,
+      borderRadius: 12,
+    },
+    input: {
+      backgroundColor: c.input,
+      color: c.text,
+      padding: 10,
+      borderRadius: 8,
+      marginBottom: 12,
+    },
+    buttons: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+    },
+    button: {
+      paddingVertical: 8,
+      paddingHorizontal: 12,
+      backgroundColor: c.tint,
+      borderRadius: 8,
+      marginLeft: 8,
+    },
+    cancel: {
+      backgroundColor: c.input,
+    },
+    buttonText: {
+      color: c.text,
+    },
+  });

--- a/helpers/firestore.ts
+++ b/helpers/firestore.ts
@@ -143,6 +143,11 @@ export async function boostWish(id: string, hours: number) {
   return updateDoc(ref, { boostedUntil });
 }
 
+export async function setFulfillmentLink(id: string, link: string) {
+  const ref = doc(db, 'wishes', id);
+  return updateDoc(ref, { fulfillmentLink: link });
+}
+
 export async function getWish(id: string): Promise<Wish | null> {
   const snap = await getDoc(doc(db, 'wishes', id));
   return snap.exists() ? ({ id: snap.id, ...(snap.data() as Omit<Wish,'id'>) } as Wish) : null;
@@ -206,6 +211,7 @@ export async function getWishesByNickname(nickname: string): Promise<Wish[]> {
       audioUrl: data.audioUrl,
       imageUrl: data.imageUrl,
       giftLink: data.giftLink,
+      fulfillmentLink: data.fulfillmentLink,
       isPoll: data.isPoll,
       optionA: data.optionA,
       optionB: data.optionB,
@@ -241,6 +247,7 @@ export async function getAllWishes(): Promise<Wish[]> {
       audioUrl: data.audioUrl,
       imageUrl: data.imageUrl,
       giftLink: data.giftLink,
+      fulfillmentLink: data.fulfillmentLink,
       isPoll: data.isPoll,
       optionA: data.optionA,
       optionB: data.optionB,

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -15,6 +15,10 @@ export interface Wish {
   audioUrl?: string;
   imageUrl?: string;
   giftLink?: string;
+  /**
+   * Link provided by a user after fulfilling the wish
+   */
+  fulfillmentLink?: string;
   isPoll?: boolean;
   optionA?: string;
   optionB?: string;


### PR DESCRIPTION
## Summary
- allow wish fulfillment links by adding a `fulfillmentLink` field
- expose helper to set the fulfillment link
- show a button in the wish page to view or add a fulfillment link
- create reusable `FulfillmentLinkDialog` modal

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686e984753e48327ace157b28a6da1be