### PR TITLE
Add onboarding flow

### DIFF
--- a/app/Onboarding.tsx
+++ b/app/Onboarding.tsx
@@ -1,0 +1,76 @@
+import React, { useRef, useState } from 'react';
+import { View, Text, StyleSheet, FlatList, Dimensions } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useRouter } from 'expo-router';
+import { useTheme } from '@/contexts/ThemeContext';
+import ThemedButton from '@/components/ThemedButton';
+
+const { width } = Dimensions.get('window');
+
+const slides = [
+  { key: '1', title: 'Post anonymously', emoji: '🤫' },
+  { key: '2', title: 'Hear others', emoji: '👂' },
+  { key: '3', title: 'Be fulfilled', emoji: '✨' },
+];
+
+export default function Page() {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const [index, setIndex] = useState(0);
+  const viewConfigRef = useRef({ viewAreaCoveragePercentThreshold: 50 });
+
+  const onViewableItemsChanged = useRef(({ viewableItems }: any) => {
+    if (viewableItems.length > 0) {
+      setIndex(viewableItems[0].index || 0);
+    }
+  }).current;
+
+  const handleDone = async () => {
+    await AsyncStorage.setItem('hasSeenOnboarding', 'true');
+    router.replace('/');
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <FlatList
+        data={slides}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onViewableItemsChanged={onViewableItemsChanged}
+        viewabilityConfig={viewConfigRef.current}
+        keyExtractor={(item) => item.key}
+        renderItem={({ item }) => (
+          <View style={[styles.slide, { width }]}>
+            <Text style={[styles.emoji]}>{item.emoji}</Text>
+            <Text style={[styles.title, { color: theme.text }]}>{item.title}</Text>
+          </View>
+        )}
+      />
+      {index === slides.length - 1 && (
+        <ThemedButton title="Get Started" onPress={handleDone} />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  slide: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emoji: {
+    fontSize: 72,
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,26 @@
 import { AppContainer } from '@/components/AppContainer';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { ThemeProvider } from '@/contexts/ThemeContext';
-import { Stack } from 'expo-router';
-import React from 'react';
+import { Stack, useRouter, usePathname } from 'expo-router';
+import React, { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 function LayoutInner() {
   const { loading } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const check = async () => {
+      const seen = await AsyncStorage.getItem('hasSeenOnboarding');
+      if (!seen && pathname !== '/onboarding') {
+        router.replace('/onboarding');
+      }
+    };
+    check();
+  }, [pathname, router]);
+
   if (loading) return null;
-  // if (!user) return <Redirect href="/auth" />;
   return <Stack screenOptions={{ headerShown: false }} />;
 }
 


### PR DESCRIPTION
## Summary
- create an Onboarding screen with a short swiper
- store `hasSeenOnboarding` when done
- redirect new users to onboarding on first launch

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ea2375e50832797b107948921f9a2