### PR TITLE
Fix pods with modular headers

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -8,6 +8,7 @@ ENV['RCT_NEW_ARCH_ENABLED'] = '0' if podfile_properties['newArchEnabled'] == 'fa
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+use_modular_headers!
 install! 'cocoapods',
   :deterministic_uuids => false
 


### PR DESCRIPTION
## Summary
- enable modular headers for all pods in the iOS Podfile
- attempted to reinstall pods

## Testing
- `rm -rf Pods`
- `pod install --repo-update --allow-root` *(fails: Invalid `Podfile` file: No such file or directory - xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_686ea81a1e5c83279c0f642d32bff8e1