### PR TITLE
Fix Hermes build issues for Expo iOS

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "icon": "./assets/images/icon.png",
     "scheme": "whisplist",
     "userInterfaceStyle": "dark",
+    "jsEngine": "jsc",
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,5 +1,5 @@
 {
-  "expo.jsEngine": "hermes",
+  "expo.jsEngine": "jsc",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "newArchEnabled": "true"
 }


### PR DESCRIPTION
## Summary
- disable Hermes by switching to JSC

## Testing
- `npm run lint`
- `npx pod-install ios` *(fails: pod command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eacc4640c8327a90b464f71949cae