### PR TITLE
Disable Hermes and Fabric for iOS

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     "scheme": "whisplist",
     "userInterfaceStyle": "dark",
     "jsEngine": "jsc",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.anonymous.WhispList",

--- a/clean-jsc-rebuild.sh
+++ b/clean-jsc-rebuild.sh
@@ -1,2 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clean and rebuild the iOS project using JSC instead of Hermes
+
+# 1. Remove previous pods, build products and Xcode derived data
+rm -rf ios/Pods ios/Podfile.lock ios/build ~/Library/Developer/Xcode/DerivedData
+
+# 2. Delete stray modulemap files that can cause React-jsc/Fabric conflicts
+find ios -name "React-jsitooling.modulemap" -type f -delete
+
+# 3. Reinstall pods with repository update
+(cd ios && pod install --repo-update)
+
+# 4. Rebuild the app
+npx expo run:ios
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -36,7 +36,7 @@ target 'WhispList' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',
+    :hermes_enabled => podfile_properties['expo.jsEngine'] == 'hermes',
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/..",
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,5 +1,5 @@
 {
   "expo.jsEngine": "jsc",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
-  "newArchEnabled": "true"
+  "newArchEnabled": "false"
 }


### PR DESCRIPTION
## Summary
- disable new architecture in app.json
- disable Fabric in Podfile.properties.json
- only enable Hermes when explicitly requested
- add a rebuild script for JSC that cleans pods and installs again

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ec132a1088327998c61000c0a1cec