### PR TITLE
fix iOS pod build config

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -11,6 +11,11 @@ platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 install! 'cocoapods',
   :deterministic_uuids => false
 
+# Allow Swift pods without module maps to generate modular headers. This avoids
+# the "redefinition of module" build errors seen when integrating Firebase
+# dependencies.
+use_modular_headers!
+
 prepare_react_native_project!
 
 target 'WhispList' do


### PR DESCRIPTION
## Summary
- allow CocoaPods modular headers so Firebase pods build correctly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ec2d196188327b2bf0cb413fc0c8c