### PR TITLE
Fix iOS build conflicts

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -55,6 +55,16 @@ target 'WhispList' do
       :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
     )
 
+    # Disable module generation for pods that conflict with React runtime
+    %w[React-RuntimeApple React-RCTRuntime React-jsc Fabric].each do |pod_name|
+      target = installer.pods_project.targets.find { |t| t.name == pod_name }
+      next unless target
+
+      target.build_configurations.each do |config|
+        config.build_settings['DEFINES_MODULE'] = 'NO'
+      end
+    end
+
     # This is necessary for Xcode 14, because it signs resource bundles by default
     # when building for devices.
     installer.target_installation_results.pod_target_installation_results

--- a/scripts/reset-ios-build.sh
+++ b/scripts/reset-ios-build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Clean all node and CocoaPods artifacts and reinstall them from scratch.
+
+set -euo pipefail
+
+# 1. Remove npm modules, CocoaPods and build artifacts
+rm -rf node_modules ios/Pods ios/Podfile.lock ios/build
+rm -rf ~/Library/Developer/Xcode/DerivedData
+
+# 2. Clear npm cache and reinstall packages
+npm cache clean --force
+npm install
+
+# 3. Reinstall CocoaPods with repository update
+(cd ios && pod install --repo-update)
+
+# Final instructions to run the app
+echo "\nProject reset complete. Now run:\n"
+echo "  npx expo start -c"
+echo "  npx expo run:ios"


### PR DESCRIPTION
## Summary
- add post_install patch to disable module generation for runtime pods
- add script to fully reset node and CocoaPods deps

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887a41adbb88327a7bb2b0ebe49b8b1