### PR TITLE
Improve iOS build cleanup

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -65,6 +65,18 @@ target 'WhispList' do
       end
     end
 
+    # Ensure no pod targets still define modules which can cause
+    # "redefinition of module" errors. Any target that still has
+    # DEFINES_MODULE = YES will be logged and set to NO.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        next unless config.build_settings['DEFINES_MODULE'] == 'YES'
+
+        Pod::UI.puts "[debug] Disabling DEFINES_MODULE for #{target.name}"
+        config.build_settings['DEFINES_MODULE'] = 'NO'
+      end
+    end
+
     # This is necessary for Xcode 14, because it signs resource bundles by default
     # when building for devices.
     installer.target_installation_results.pod_target_installation_results

--- a/scripts/deep-clean-ios.sh
+++ b/scripts/deep-clean-ios.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fully reset iOS build environment and reinstall dependencies
+# Run from the root of the project
+
+# 1. Remove node modules and iOS build artifacts
+rm -rf node_modules ios/Pods ios/Podfile.lock ios/build
+rm -rf ~/Library/Developer/Xcode/DerivedData
+
+# 2. Clear npm cache
+npm cache clean --force
+
+# 3. Reinstall npm packages and CocoaPods
+npm install
+(cd ios && pod install --repo-update)
+
+# 4. Run the app on iOS simulator
+npx expo run:ios


### PR DESCRIPTION
## Summary
- disable `DEFINES_MODULE` on any pod target after install and log which ones were changed
- add script to fully reset iOS build artifacts and reinstall dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887a68ce4f48327b4773949868d2050