### PR TITLE
Fix EAS projectId cleanup

### DIFF
--- a/app.json
+++ b/app.json
@@ -47,9 +47,6 @@
       "typedRoutes": true
     },
     "extra": {
-      "eas": {
-        "projectId": "whisplist-f6b0d"
-      },
       "EXPO_PUBLIC_FIREBASE_API_KEY": "AIzaSyDVBdi1qJOtOPX6-jGOZgj8uwh9tM7uomc",
       "EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN": "whisplist-f6b0d.firebaseapp.com",
       "EXPO_PUBLIC_FIREBASE_PROJECT_ID": "whisplist-f6b0d",

--- a/scripts/fix-eas-project.js
+++ b/scripts/fix-eas-project.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * Script to remove invalid EAS projectId from app.json and run `eas init`.
+ * If EAS CLI is not logged in, `eas init` will fail and show an error message.
+ */
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const APP_JSON = 'app.json';
+
+function cleanProjectId() {
+  const raw = fs.readFileSync(APP_JSON, 'utf8');
+  const appJson = JSON.parse(raw);
+
+  const projectId = appJson.expo?.extra?.eas?.projectId;
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(projectId || '');
+
+  if (projectId && !isUuid) {
+    delete appJson.expo.extra.eas.projectId;
+    if (Object.keys(appJson.expo.extra.eas).length === 0) {
+      delete appJson.expo.extra.eas;
+    }
+    fs.writeFileSync(APP_JSON, JSON.stringify(appJson, null, 2));
+    console.log('Removed invalid eas.projectId from app.json');
+  }
+}
+
+function runEasInit() {
+  try {
+    execSync('eas init', { stdio: 'inherit' });
+  } catch (err) {
+    console.error('`eas init` failed:', err.message);
+  }
+}
+
+cleanProjectId();
+runEasInit();
+


### PR DESCRIPTION
## Summary
- remove the stale `eas.projectId` from `app.json`
- add a helper script to clean the projectId and invoke `eas init`

## Testing
- `npm run lint`
- `node scripts/fix-eas-project.js` *(fails: requires Expo login)*

------
https://chatgpt.com/codex/tasks/task_e_6887acc6ab28832785e93b8ad0c0c29e