### PR TITLE
Fix iOS Podfile to fully disable New Architecture

### DIFF
--- a/Podfile.properties.json
+++ b/Podfile.properties.json
@@ -1,5 +1,5 @@
 {
-  "jsEngine": "jsc",
+  "expo.jsEngine": "jsc",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "newArchEnabled": "false"
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,11 +1,12 @@
-require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
-require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
-
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 
+# Ensure the New Architecture is completely disabled
 ENV['RCT_NEW_ARCH_ENABLED'] = '0' if podfile_properties['newArchEnabled'] == 'false'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
+
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 install! 'cocoapods',


### PR DESCRIPTION
## Summary
- disable New Architecture before loading React Native pods
- rename jsEngine key to `expo.jsEngine` in Podfile properties

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887f2f7dc488327b03febc848a404f3