### PR TITLE
Fix Podfile path and add test

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 require 'json'
-podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
+podfile_properties = JSON.parse(File.read(File.join(__dir__, '..', 'Podfile.properties.json'))) rescue {}
 
 # Ensure the New Architecture is completely disabled
 ENV['RCT_NEW_ARCH_ENABLED'] = '0' if podfile_properties['newArchEnabled'] == 'false'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "node tests/podfile.test.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/tests/podfile.test.js
+++ b/tests/podfile.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const podfilePath = path.join(__dirname, '..', 'ios', 'Podfile');
+const content = fs.readFileSync(podfilePath, 'utf8');
+const expected = "File.join(__dir__, '..', 'Podfile.properties.json')";
+assert(
+  content.includes(expected),
+  `Expected Podfile to load properties using ${expected}`
+);
+console.log('Podfile test passed');


### PR DESCRIPTION
## Summary
- fix path to `Podfile.properties.json` in `ios/Podfile`
- add a basic Node test to ensure the Podfile uses the root properties file
- expose the test via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887f6506eb08327b463a9770a64d975