### PR TITLE
Disable new arch and ensure Podfile uses root properties

### DIFF
--- a/Podfile.properties.json
+++ b/Podfile.properties.json
@@ -1,5 +1,4 @@
 {
   "expo.jsEngine": "jsc",
-  "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "newArchEnabled": "false"
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -6,6 +6,7 @@ ENV['RCT_NEW_ARCH_ENABLED'] = '0' if podfile_properties['newArchEnabled'] == 'fa
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+ENV["PODFILE_PROPERTIES"] ||= File.expand_path("../Podfile.properties.json", __dir__)
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'


### PR DESCRIPTION
## Summary
- update `Podfile.properties.json` to only contain expo.jsEngine and newArchEnabled
- inject `PODFILE_PROPERTIES` environment variable in iOS Podfile so RN scripts use root properties file

## Testing
- `npm test`
- `pod install --allow-root` *(fails: Invalid `Podfile` file: No such file or directory - xcodebuild)*
- `npx eas-cli build -p ios --clear-cache --profile development` *(fails: requires interactive install of eas-cli)*

------
https://chatgpt.com/codex/tasks/task_e_6888e3c0f3d883278324f758917bb854