### PR TITLE
Fix iOS build by enabling modular headers

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -13,6 +13,10 @@ platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 install! 'cocoapods',
   :deterministic_uuids => false
 
+# Allow Swift pods without module maps to generate modular headers.
+# This avoids "Module not found" build failures for Firebase libraries.
+use_modular_headers!
+
 
 prepare_react_native_project!
 


### PR DESCRIPTION
## Summary
- enable `use_modular_headers!` in Podfile so Firebase pods build properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688927e8de4483278bae75622b6a125a