### PR TITLE
Fix firebase imports for web

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,11 +1,6 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import { initializeApp } from 'firebase/app';
-import {
-  getAuth,
-  getReactNativePersistence,
-  initializeAuth,
-} from 'firebase/auth';
+import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 
@@ -26,6 +21,7 @@ if (!firebaseConfig.apiKey) {
 let app;
 try {
   app = initializeApp(firebaseConfig);
+  console.log('Firebase app initialized');
 } catch (err) {
   console.error('Failed to initialize Firebase app', err);
 }
@@ -35,6 +31,8 @@ if (Platform.OS === 'web') {
   auth = getAuth(app);
 } else {
   // ✅ Use AsyncStorage for persistent login on native
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  const { getReactNativePersistence, initializeAuth } = require('firebase/auth/react-native');
   auth = initializeAuth(app, {
     persistence: getReactNativePersistence(AsyncStorage),
   });
@@ -42,6 +40,8 @@ if (Platform.OS === 'web') {
 
 if (!auth) {
   console.error('Firebase auth not initialized');
+} else {
+  console.log('Firebase Auth initialized');
 }
 
 const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- stop importing native-only modules on web
- conditionally require `AsyncStorage` and `firebase/auth/react-native`
- log when Firebase and Auth initialize

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889263f7ef883278032a55b54be1c56