### PR TITLE
Adjust Firestore rules for WhispList

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,9 +9,25 @@ service cloud.firestore {
         exists(/databases/$(database)/documents/users/$(userId)/followers/$(request.auth.uid));
     }
 
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
     match /wishes/{wishId} {
-      allow read: if isBoosted() || isFollowerOf(resource.data.userId);
-      allow write: if request.auth != null;
+      allow read: if true;
+      allow create: if isSignedIn() && request.auth.uid == request.resource.data.userId;
+      allow update, delete: if isSignedIn() && request.auth.uid == resource.data.userId;
+    }
+
+    match /wishes/{wishId}/comments/{commentId} {
+      allow read: if true;
+      allow create: if isSignedIn() && request.auth.uid == request.resource.data.userId;
+      allow update, delete: if isSignedIn() && request.auth.uid == resource.data.userId;
+    }
+
+    match /users/{userId} {
+      allow read: if true;
+      allow create, update, delete: if isSignedIn() && request.auth.uid == userId;
     }
 
     match /users/{userId}/followers/{followerId} {
@@ -20,6 +36,10 @@ service cloud.firestore {
 
     match /users/{userId}/following/{targetUserId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- update security rules so any user can read wishes, comments and profiles
- allow authenticated users (anonymous or signed-in) to create wishes and comments
- restrict updates/removals to the authenticated owner
- keep follower/following rules intact and add catch-all deny rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a56705a948327b9181b89667a6081