### PR TITLE
Update Firestore rules for anonymous access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,25 +9,31 @@ service cloud.firestore {
         exists(/databases/$(database)/documents/users/$(userId)/followers/$(request.auth.uid));
     }
 
+    function isAuthenticated() {
+      return request.auth != null &&
+        (request.auth.token.firebase.sign_in_provider == 'anonymous' ||
+         request.auth.token.firebase.sign_in_provider == 'password');
+    }
+
     function isSignedIn() {
-      return request.auth != null;
+      return isAuthenticated();
     }
 
     match /wishes/{wishId} {
       allow read: if true;
-      allow create: if isSignedIn() && request.auth.uid == request.resource.data.userId;
-      allow update, delete: if isSignedIn() && request.auth.uid == resource.data.userId;
+      allow create: if isAuthenticated() && request.auth.uid == request.resource.data.userId;
+      allow update, delete: if isAuthenticated() && request.auth.uid == resource.data.userId;
     }
 
     match /wishes/{wishId}/comments/{commentId} {
       allow read: if true;
-      allow create: if isSignedIn() && request.auth.uid == request.resource.data.userId;
-      allow update, delete: if isSignedIn() && request.auth.uid == resource.data.userId;
+      allow create: if isAuthenticated() && request.auth.uid == request.resource.data.userId;
+      allow update, delete: if isAuthenticated() && request.auth.uid == resource.data.userId;
     }
 
     match /users/{userId} {
       allow read: if true;
-      allow create, update, delete: if isSignedIn() && request.auth.uid == userId;
+      allow create, update, delete: if isAuthenticated() && request.auth.uid == userId;
     }
 
     match /users/{userId}/followers/{followerId} {


### PR DESCRIPTION
## Summary
- allow anonymous and signed-in users to create/update/delete their own wishes and comments
- limit user profile writes to authenticated owners
- add `isAuthenticated()` helper to handle anonymous and password sign-in providers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a594bfa848327bc70065a7bd5833e