### PR TITLE
Add Stripe wish boosting

### DIFF
--- a/app/(tabs)/boosted.tsx
+++ b/app/(tabs)/boosted.tsx
@@ -179,7 +179,8 @@ export default function Page() {
           )}
           {item.boostedUntil && item.boostedUntil.toDate && (
             <Text style={styles.boostedLabel}>
-              🚀 Boosted{timeLeft ? ` (${timeLeft})` : ''}
+              🚀 {item.boosted === 'stripe' ? 'Boosted via Stripe' : 'Boosted'}
+              {timeLeft ? ` (${timeLeft})` : ''}
             </Text>
           )}
         </TouchableOpacity>

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -208,7 +208,16 @@ export default function Page() {
     }
   };
 
-  const renderWish = ({ item }: { item: Wish }) => (
+  const renderWish = ({ item }: { item: Wish }) => {
+    const isBoosted =
+      item.boostedUntil && item.boostedUntil.toDate && item.boostedUntil.toDate() > new Date();
+    const timeLeft = isBoosted ? formatTimeLeft(item.boostedUntil.toDate()) : '';
+    const canBoost =
+      user &&
+      item.userId === user.uid &&
+      (!item.boostedUntil || !item.boostedUntil.toDate || item.boostedUntil.toDate() < new Date());
+
+    return (
     <View style={[styles.wishItem, { backgroundColor: typeInfo[item.type || 'wish'].color }]}>
       <TouchableOpacity onPress={() => router.push(`/wish/${item.id}`)} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
         <Text style={styles.wishCategory}>
@@ -226,8 +235,22 @@ export default function Page() {
         ) : (
           <Text style={styles.likes}>❤️ {item.likes}</Text>
         )}
+        {isBoosted && (
+          <Text style={styles.boostedLabel}>
+            🚀 {item.boosted === 'stripe' ? 'Boosted via Stripe' : 'Boosted'}
+            {timeLeft ? ` (${timeLeft})` : ''}
+          </Text>
+        )}
       </TouchableOpacity>
 
+      {canBoost && (
+        <TouchableOpacity
+          onPress={() => router.push(`/boost/${item.id}`)}
+          style={{ marginTop: 4 }}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+          <Text style={{ color: '#facc15' }}>Boost 🚀</Text>
+        </TouchableOpacity>
+      )}
 
       <TouchableOpacity
         onPress={() => {
@@ -241,6 +264,7 @@ export default function Page() {
       </TouchableOpacity>
     </View>
   );
+  };
 
   try {
     return (
@@ -467,6 +491,11 @@ const styles = StyleSheet.create({
   pollText: {
     color: '#fff',
     fontSize: 14,
+  },
+  boostedLabel: {
+    color: '#facc15',
+    fontSize: 12,
+    marginTop: 4,
   },
   errorText: {
     color: '#f87171',

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -597,6 +597,12 @@ useEffect(() => {
             const timeLeft = isBoosted
               ? formatTimeLeft(item.boostedUntil.toDate())
               : '';
+            const canBoost =
+              user &&
+              item.userId === user.uid &&
+              (!item.boostedUntil ||
+                !item.boostedUntil.toDate ||
+                item.boostedUntil.toDate() < new Date());
 
             return (
             <View
@@ -636,11 +642,22 @@ useEffect(() => {
                   <Text style={styles.likeText}>❤️ {item.likes}</Text>
                 )}
                 {isBoosted && (
-                    <Text style={styles.boostedLabel}>
-                      🚀 Boosted{timeLeft ? ` (${timeLeft})` : ''}
-                    </Text>
-                  )}
+                  <Text style={styles.boostedLabel}>
+                    🚀 {item.boosted === 'stripe' ? 'Boosted via Stripe' : 'Boosted'}
+                    {timeLeft ? ` (${timeLeft})` : ''}
+                  </Text>
+                )}
               </TouchableOpacity>
+
+              {canBoost && (
+                <TouchableOpacity
+                  onPress={() => router.push(`/boost/${item.id}`)}
+                  style={{ marginTop: 4 }}
+                  hitSlop={HIT_SLOP}
+                >
+                  <Text style={{ color: '#facc15' }}>Boost 🚀</Text>
+                </TouchableOpacity>
+              )}
 
               {user && item.userId && user.uid !== item.userId && (
                 <TouchableOpacity

--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -1,0 +1,82 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
+import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+
+export default function BoostPage() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { user } = useAuth();
+  const router = useRouter();
+  const { theme } = useTheme();
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const handleBoost = async () => {
+    if (!id || !user) return;
+    setLoading(true);
+    try {
+      const resp = await fetch(
+        `https://us-central1-${process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID}.cloudfunctions.net/createCheckoutSession`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ wishId: id, userId: user.uid }),
+        }
+      );
+      const data = await resp.json();
+      if (data.url) {
+        await WebBrowser.openBrowserAsync(data.url);
+        setDone(true);
+      }
+    } catch (err) {
+      console.error('Failed to create checkout session', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      {done ? (
+        <>
+          <Text style={{ color: theme.text, marginBottom: 20 }}>
+            Thanks for boosting! Your wish will be highlighted shortly.
+          </Text>
+          <TouchableOpacity onPress={() => router.back()} style={styles.button}>
+            <Text style={styles.buttonText}>Go Back</Text>
+          </TouchableOpacity>
+        </>
+      ) : (
+        <>
+          <Text style={{ color: theme.text, marginBottom: 20 }}>
+            Boost this wish for $0.50
+          </Text>
+          <TouchableOpacity onPress={handleBoost} style={styles.button} disabled={loading}>
+            {loading ? <ActivityIndicator color="#000" /> : <Text style={styles.buttonText}>Boost 🚀</Text>}
+          </TouchableOpacity>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  button: {
+    backgroundColor: '#facc15',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#000',
+    fontWeight: '600',
+  },
+});

--- a/functions/createCheckoutSession.ts
+++ b/functions/createCheckoutSession.ts
@@ -1,0 +1,53 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+});
+
+const db = admin.firestore();
+
+export const createCheckoutSession = functions.https.onRequest(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method not allowed');
+    return;
+  }
+
+  const { wishId, userId } = req.body;
+  if (!wishId || !userId) {
+    res.status(400).send('Missing parameters');
+    return;
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            unit_amount: 50,
+            product_data: { name: 'WhispList Boost' },
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: { wishId, userId },
+      success_url: 'https://example.com/success',
+      cancel_url: 'https://example.com/cancel',
+    });
+
+    await db.collection('boostPayments').doc(session.id).set({
+      wishId,
+      userId,
+      status: 'pending',
+    });
+
+    res.json({ url: session.url, sessionId: session.id });
+  } catch (err) {
+    console.error('Error creating checkout session', err);
+    res.status(500).send('Internal error');
+  }
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -67,3 +67,5 @@ exports.notifyWishComment = functions.firestore
     }
     return null;
   });
+exports.createCheckoutSession = require('./createCheckoutSession').createCheckoutSession;
+exports.stripeWebhook = require('./stripeWebhook').stripeWebhook;

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,10 +2,13 @@
   "name": "whisplist-functions",
   "version": "1.0.0",
   "main": "index.js",
-  "engines": { "node": "18" },
+  "engines": {
+    "node": "18"
+  },
   "dependencies": {
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^4.4.1",
-    "expo-server-sdk": "^4.2.0"
+    "expo-server-sdk": "^4.2.0",
+    "stripe": "^11.17.0"
   }
 }

--- a/functions/stripeWebhook.ts
+++ b/functions/stripeWebhook.ts
@@ -1,0 +1,47 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+});
+
+const db = admin.firestore();
+
+export const stripeWebhook = functions.https.onRequest(async (req, res) => {
+  const sig = req.headers['stripe-signature'] as string;
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      req.rawBody,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET as string
+    );
+  } catch (err) {
+    console.error('Webhook verification failed', err);
+    res.status(400).send('Webhook Error');
+    return;
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const wishId = session.metadata?.wishId as string;
+    const sessionId = session.id;
+
+    const batch = db.batch();
+    if (wishId) {
+      batch.update(db.collection('wishes').doc(wishId), {
+        boostedUntil: admin.firestore.Timestamp.fromDate(
+          new Date(Date.now() + 24 * 60 * 60 * 1000)
+        ),
+        boosted: 'stripe',
+      });
+    }
+    batch.update(db.collection('boostPayments').doc(sessionId), {
+      status: 'completed',
+    });
+    await batch.commit();
+  }
+
+  res.json({ received: true });
+});

--- a/helpers/firestore.ts
+++ b/helpers/firestore.ts
@@ -143,6 +143,18 @@ export async function boostWish(id: string, hours: number) {
   return updateDoc(ref, { boostedUntil });
 }
 
+export async function createBoostCheckout(wishId: string, userId: string) {
+  const resp = await fetch(
+    `https://us-central1-${process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID}.cloudfunctions.net/createCheckoutSession`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ wishId, userId }),
+    }
+  );
+  return (await resp.json()) as { url: string; sessionId: string };
+}
+
 export async function setFulfillmentLink(id: string, link: string) {
   const ref = doc(db, 'wishes', id);
   return updateDoc(ref, { fulfillmentLink: link });

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -12,6 +12,7 @@ export interface Wish {
   photoURL?: string;
   isAnonymous?: boolean;
   boostedUntil?: any;
+  boosted?: string;
   audioUrl?: string;
   imageUrl?: string;
   giftLink?: string;


### PR DESCRIPTION
## Summary
- introduce cloud functions for Stripe payments
- add Boost checkout screen
- support boosted status on wish cards
- allow boosting from wish details
- update Wish type and Firestore helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a67ff486883279ef35047773a6e16