### PR TITLE
Add reflection history and daily reminders

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -324,6 +324,16 @@ useEffect(() => {
         ...(imageUrl && { imageUrl }),
       });
 
+      try {
+        const raw = await AsyncStorage.getItem('reflectionHistory');
+        const history = raw ? JSON.parse(raw) : [];
+        history.unshift({ text: wish.trim(), timestamp: Date.now() });
+        if (history.length > 7) history.splice(7);
+        await AsyncStorage.setItem('reflectionHistory', JSON.stringify(history));
+      } catch (err) {
+        console.error('Failed to save reflection history', err);
+      }
+
       setWish('');
       setOptionA('');
       setOptionB('');


### PR DESCRIPTION
## Summary
- save recent reflections after posting a wish
- display reflection history, boost impact, and reminder toggle in Profile tab
- show avatar glow on streak and boosts with sparkle effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a72c03fdc8327ad4a881cfd3c64f0