### PR TITLE
Handle Firestore permission errors

### DIFF
--- a/app/(tabs)/boosted.tsx
+++ b/app/(tabs)/boosted.tsx
@@ -58,13 +58,18 @@ export default function Page() {
       await Promise.all(
         ids.map(async (id) => {
           if (publicStatus[id] === undefined) {
-            const snap = await getDoc(doc(db, 'users', id));
-            setPublicStatus((prev) => ({
-              ...prev,
-              [id]: snap.exists()
-                ? snap.data().publicProfileEnabled !== false
-                : false,
-            }));
+            try {
+              const snap = await getDoc(doc(db, 'users', id));
+              setPublicStatus((prev) => ({
+                ...prev,
+                [id]: snap.exists()
+                  ? snap.data().publicProfileEnabled !== false
+                  : false,
+              }));
+            } catch (err) {
+              console.warn('Failed to fetch profile status', err);
+              setPublicStatus((prev) => ({ ...prev, [id]: false }));
+            }
           }
         })
       );

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -208,7 +208,7 @@ export default function Page() {
         <Animated.Text
           style={[styles.boostCount, { transform: [{ scale: boostAnim }] }]}
         >
-          You've boosted {boostCount} wishes 🌟
+          You&apos;ve boosted {boostCount} wishes 🌟
         </Animated.Text>
         <Text style={styles.info}>
           Your boosts earned ❤️ {boostImpact.likes} likes, 💬 {boostImpact.comments} comments
@@ -226,7 +226,7 @@ export default function Page() {
       {streakCount > 0 && (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>📅 Streak</Text>
-          <Text style={styles.info}>🔥 {streakCount}-day streak — you're on fire!</Text>
+          <Text style={styles.info}>🔥 {streakCount}-day streak — you&apos;re on fire!</Text>
           {streakCount > 3 && <ConfettiCannon count={40} origin={{ x: 0, y: 0 }} fadeOut />}
         </View>
       )}
@@ -234,7 +234,7 @@ export default function Page() {
       {profile?.giftsReceived != null && (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>💝 Gifts</Text>
-          <Text style={styles.info}>You've received {profile.giftsReceived} gifts</Text>
+          <Text style={styles.info}>You&apos;ve received {profile.giftsReceived} gifts</Text>
         </View>
       )}
 
@@ -242,7 +242,7 @@ export default function Page() {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>🎁 Referrals</Text>
           <Text style={styles.info}>
-            You've invited {referralCount} people — max {Math.max(0, 4 - referralCount)} more to unlock another reward
+            You&apos;ve invited {referralCount} people — max {Math.max(0, 4 - referralCount)} more to unlock another reward
           </Text>
         </View>
       )}
@@ -286,7 +286,7 @@ export default function Page() {
       {dailyPrompt && (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>🧠 Reflection</Text>
-          <Text style={styles.info}>Yesterday, you said: '{dailyPrompt}'</Text>
+            <Text style={styles.info}>Yesterday, you said: &apos;{dailyPrompt}&apos;</Text>
         </View>
       )}
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -324,7 +324,7 @@ export default function Page() {
       {avatarUrl && <Image source={{ uri: avatarUrl }} style={styles.avatar} />}
       {profile?.boostCredits !== undefined && (
         <ThemedText style={styles.section}>
-          You've earned {profile.boostCredits} free boosts!
+          You&apos;ve earned {profile.boostCredits} free boosts!
         </ThemedText>
       )}
       <ThemedButton title="Refer a Friend" onPress={handleShareInvite} />

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -162,8 +162,13 @@ export default function Page() {
       if (data) {
         setWish(data);
         if (data.userId) {
-          const snap = await getDoc(doc(db, 'users', data.userId));
-          setOwner(snap.exists() ? snap.data() : null);
+          try {
+            const snap = await getDoc(doc(db, 'users', data.userId));
+            setOwner(snap.exists() ? snap.data() : null);
+          } catch (err) {
+            console.warn('Failed to fetch wish owner', err);
+            setOwner(null);
+          }
         }
       }
     } catch (err) {
@@ -230,11 +235,16 @@ try {
       await Promise.all(
         Array.from(ids).map(async (uid) => {
           if (publicStatus[uid] === undefined) {
-            const snap = await getDoc(doc(db, 'users', uid));
-            setPublicStatus((prev) => ({
-              ...prev,
-              [uid]: snap.exists() ? snap.data().publicProfileEnabled !== false : false,
-            }));
+            try {
+              const snap = await getDoc(doc(db, 'users', uid));
+              setPublicStatus((prev) => ({
+                ...prev,
+                [uid]: snap.exists() ? snap.data().publicProfileEnabled !== false : false,
+              }));
+            } catch (err) {
+              console.warn('Failed to fetch user status', err);
+              setPublicStatus((prev) => ({ ...prev, [uid]: false }));
+            }
           }
         })
       );
@@ -389,7 +399,7 @@ try {
   }, [router, wish]);
 
   const openGiftLink = useCallback((link: string) => {
-    Alert.alert('Leaving WhispList', "You're leaving WhispList to send a gift.", [
+    Alert.alert('Leaving WhispList', "You&apos;re leaving WhispList to send a gift.", [
       { text: 'Cancel', style: 'cancel' },
       { text: 'Continue', onPress: () => WebBrowser.openBrowserAsync(link) },
     ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-audio": "~0.4.7",
         "expo-auth-session": "~6.2.0",
         "expo-blur": "~14.1.5",
+        "expo-clipboard": "^7.1.5",
         "expo-constants": "~17.1.6",
         "expo-dev-client": "~5.2.4",
         "expo-device": "~7.1.4",
@@ -12382,6 +12383,17 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/expo-clipboard": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-7.1.5.tgz",
+      "integrity": "sha512-TCANUGOxouoJXxKBW5ASJl2WlmQLGpuZGemDCL2fO5ZMl57DGTypUmagb0CVUFxDl0yAtFIcESd78UsF9o64aw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/expo-constants": {
       "version": "17.1.7",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-audio": "~0.4.7",
     "expo-auth-session": "~6.2.0",
     "expo-blur": "~14.1.5",
+    "expo-clipboard": "^7.1.5",
     "expo-constants": "~17.1.6",
     "expo-dev-client": "~5.2.4",
     "expo-device": "~7.1.4",


### PR DESCRIPTION
## Summary
- guard Firestore lookups with `try/catch`
- escape apostrophes in several UI strings
- add `expo-clipboard` to dependencies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a88f9e2ec83279f3f8a2ff038a133