### PR TITLE
Add private journal feature

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -53,6 +53,15 @@ export default function Layout() {
         }}
       />
       <Tabs.Screen
+        name="journal"
+        options={{
+          title: 'Journal',
+          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+            <Ionicons name="book-outline" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="profile"
         options={{
           title: 'Profile',

--- a/app/(tabs)/journal.tsx
+++ b/app/(tabs)/journal.tsx
@@ -1,0 +1,1 @@
+export { default } from '../journal';

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -218,6 +218,12 @@ export default function Page() {
       <TouchableOpacity style={styles.button} onPress={handleSave} disabled={saving}>
         <Text style={styles.buttonText}>{saving ? 'Saving...' : 'Save Profile'}</Text>
       </TouchableOpacity>
+      <TouchableOpacity
+        style={[styles.button, { marginBottom: 10 }]}
+        onPress={() => router.push('/journal')}
+      >
+        <Text style={styles.buttonText}>Open Journal</Text>
+      </TouchableOpacity>
 
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>🔥 Boosts</Text>

--- a/app/journal.tsx
+++ b/app/journal.tsx
@@ -1,8 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  StyleSheet,
+  Alert,
+} from 'react-native';
 import { formatDistanceToNow } from 'date-fns';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { collection, addDoc, serverTimestamp, query, orderBy, getDocs } from 'firebase/firestore';
+import { addWish } from '../helpers/firestore';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { db } from '../firebase';
@@ -21,28 +30,50 @@ export default function JournalPage() {
   const [entries, setEntries] = useState<any[]>([]);
   const [streak, setStreak] = useState(0);
   const [mood, setMood] = useState('😊');
-  const [showHistory, setShowHistory] = useState(false);
   const [usePrompt, setUsePrompt] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [moodSummary, setMoodSummary] = useState<Record<string, number>>({});
 
   useEffect(() => {
     const load = async () => {
-      const today = new Date().toISOString().split('T')[0];
-      const savedDate = await AsyncStorage.getItem('journalPromptDate');
-      const savedPrompt = await AsyncStorage.getItem('journalPromptText');
-      if (savedDate === today && savedPrompt) {
+      const savedPrompt = await AsyncStorage.getItem('dailyPromptText');
+      if (savedPrompt) {
         setPrompt(savedPrompt);
       } else {
         const p = prompts[Math.floor(Math.random() * prompts.length)];
         setPrompt(p);
-        await AsyncStorage.setItem('journalPromptDate', today);
-        await AsyncStorage.setItem('journalPromptText', p);
+        await AsyncStorage.setItem('dailyPromptText', p);
       }
       const sc = await AsyncStorage.getItem('journalStreakCount');
       setStreak(sc ? parseInt(sc, 10) : 0);
       if (user) {
         const q = query(collection(db, 'users', user.uid, 'journalEntries'), orderBy('timestamp', 'desc'));
         const snap = await getDocs(q);
-        setEntries(snap.docs.map(d => ({ id: d.id, ...(d.data() as any) })));
+        let loaded = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) }));
+        const offlineRaw = await AsyncStorage.getItem('offlineJournalEntries');
+        if (offlineRaw) {
+          try {
+            const offline = JSON.parse(offlineRaw) as any[];
+            for (const o of offline) {
+              await addDoc(collection(db, 'users', user.uid, 'journalEntries'), {
+                text: o.text,
+                mood: o.mood,
+                prompt: o.prompt,
+                timestamp: serverTimestamp(),
+              });
+              loaded.unshift({ id: Math.random().toString(), ...o });
+            }
+            await AsyncStorage.removeItem('offlineJournalEntries');
+          } catch (err) {
+            console.warn('Failed to sync offline journal entries', err);
+          }
+        }
+        setEntries(loaded);
+        const summary: Record<string, number> = {};
+        loaded.slice(0, 7).forEach(e => {
+          if (e.mood) summary[e.mood] = (summary[e.mood] || 0) + 1;
+        });
+        setMoodSummary(summary);
       }
     };
     load();
@@ -66,33 +97,71 @@ export default function JournalPage() {
 
   const handlePost = async () => {
     if (!entry.trim() || !user) return;
-    await addDoc(collection(db, 'users', user.uid, 'journalEntries'), {
+    const data = {
       text: entry.trim(),
       ...(usePrompt ? { prompt } : {}),
       mood,
-      date: new Date().toISOString().split('T')[0],
-      timestamp: serverTimestamp(),
-    });
+    };
+    try {
+      await addDoc(collection(db, 'users', user.uid, 'journalEntries'), {
+        ...data,
+        timestamp: serverTimestamp(),
+      });
+    } catch (err) {
+      console.warn('Failed to save entry online', err);
+      const offlineRaw = await AsyncStorage.getItem('offlineJournalEntries');
+      const offline = offlineRaw ? JSON.parse(offlineRaw) : [];
+      offline.push({ ...data, timestamp: Date.now() });
+      await AsyncStorage.setItem('offlineJournalEntries', JSON.stringify(offline));
+      Alert.alert('Saved offline', 'Your entry will sync when online.');
+    }
     setEntries([
       {
         id: Math.random().toString(),
-        text: entry.trim(),
-        ...(usePrompt ? { prompt } : {}),
-        mood,
-        date: new Date().toISOString().split('T')[0],
+        ...data,
         timestamp: new Date(),
       },
       ...entries,
     ]);
+    setMoodSummary(prev => ({
+      ...prev,
+      [mood]: (prev[mood] || 0) + 1,
+    }));
     setEntry('');
     await updateStreak();
   };
 
+  const shareAsWish = async (text: string) => {
+    if (!user) return;
+    try {
+      await addWish({
+        text,
+        category: 'wish',
+        type: 'wish',
+        userId: user.uid,
+        displayName: '',
+        photoURL: '',
+        isAnonymous: true,
+      });
+      Alert.alert('Wish posted!');
+    } catch (err) {
+      console.error('Failed to share as wish', err);
+    }
+  };
+
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <Text style={[styles.header, { color: theme.text }]}>Your Private Journal ✨</Text>
       {usePrompt && <Text style={[styles.prompt, { color: theme.text }]}>{prompt}</Text>}
       {streak > 0 && (
-        <Text style={[styles.streak, { color: theme.tint }]}>🧠 You’ve written {streak} days in a row</Text>
+        <Text style={[styles.streak, { color: theme.tint }]}>🔥 {streak}-day streak</Text>
+      )}
+      {Object.keys(moodSummary).length > 0 && (
+        <Text style={[styles.summary, { color: theme.text }]}> 
+          {Object.entries(moodSummary)
+            .map(([m, c]) => `${m} ${c}`)
+            .join('  ')}
+        </Text>
       )}
       <View style={styles.row}>
         {['😢','😐','😊','😄'].map((m) => (
@@ -115,34 +184,46 @@ export default function JournalPage() {
       <TouchableOpacity style={[styles.button, { backgroundColor: theme.tint }]} onPress={handlePost}>
         <Text style={styles.buttonText}>Save Entry</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => setShowHistory((s) => !s)} style={{ marginTop: 10 }}>
-        <Text style={{ color: theme.tint }}>{showHistory ? 'Hide' : 'Show'} Past Entries</Text>
-      </TouchableOpacity>
-      {showHistory && (
-        <FlatList
-          data={entries.slice(0, 7)}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <View style={styles.entryItem}>
-              <Text style={[styles.entryText, { color: theme.text }]}>
-                {item.mood || '😊'} {item.text}
-              </Text>
-              <Text style={styles.entryDate}>
-                {item.timestamp?.seconds
-                  ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), { addSuffix: true })
-                  : 'Just now'}
-              </Text>
-            </View>
-          )}
-          style={{ marginTop: 10 }}
-        />
-      )}
+      <FlatList
+        data={entries.slice(0, 7)}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            onPress={() => setExpandedId(expandedId === item.id ? null : item.id)}
+            style={styles.entryItem}
+          >
+            <Text style={[styles.entryText, { color: theme.text }]}> 
+              {item.mood || '😊'}{' '}
+              {expandedId === item.id
+                ? item.text
+                : item.text.length > 80
+                  ? item.text.slice(0, 80) + '...'
+                  : item.text}
+            </Text>
+            <Text style={styles.entryDate}>
+              {item.timestamp?.seconds
+                ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), { addSuffix: true })
+                : 'Just now'}
+            </Text>
+            {expandedId === item.id && (
+              <TouchableOpacity onPress={() => shareAsWish(item.text)}>
+                <Text style={{ color: theme.tint }}>📤 Turn this into a wish</Text>
+              </TouchableOpacity>
+            )}
+          </TouchableOpacity>
+        )}
+        ListEmptyComponent={() => (
+          <Text style={[styles.entryText, { color: theme.text }]}>You haven’t written yet this week 💭</Text>
+        )}
+        style={{ marginTop: 10 }}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 20 },
+  header: { fontSize: 20, fontWeight: '600', marginBottom: 10, textAlign: 'center' },
   prompt: { fontSize: 16, marginBottom: 10, fontWeight: '600' },
   streak: { marginBottom: 10 },
   input: { padding: 12, borderRadius: 10, marginBottom: 10, height: 100 },
@@ -152,4 +233,5 @@ const styles = StyleSheet.create({
   entryText: { fontSize: 14 },
   entryDate: { fontSize: 12, color: '#888' },
   row: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
+  summary: { textAlign: 'center', marginBottom: 10 },
 });


### PR DESCRIPTION
## Summary
- add Journal tab to bottom navigation
- link to journal from profile page
- build journal page with daily prompt, mood tracking and offline support
- allow converting journal entries into wishes

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a90235fc0832784c729d91c4ebdee