### PR TITLE
Fix optional wishId TypeScript error

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -938,7 +938,7 @@ useEffect(() => {
                   <TouchableOpacity
                     onPress={async () => {
                       try {
-                        await addDoc(collection(db, 'wishes', confirmGift.wishId, 'gifts'), {
+                        await addDoc(collection(db, 'wishes', confirmGift!.wishId!, 'gifts'), {
                           message: thanksMessage,
                           sender: user?.uid || 'anon',
                           timestamp: serverTimestamp(),


### PR DESCRIPTION
## Summary
- fix addDoc call by asserting confirmGift.wishId is defined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a927acb9c832785ce897c49a87c4a