### PR TITLE
Improve wish post UI & add developer analytics

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -56,6 +56,7 @@ interface Profile {
   stripeAccountId?: string;
   giftsReceived?: number;
   referralDisplayName?: string;
+  developerMode?: boolean;
 }
 
 interface AuthContextValue {
@@ -133,6 +134,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }): ReactElemen
             data.publicProfileEnabled = true;
           }
           if (data.boostCredits === undefined) data.boostCredits = 0;
+          if (data.developerMode === undefined) data.developerMode = false;
           setProfile(data);
         } else {
           const data: Profile = {
@@ -144,6 +146,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }): ReactElemen
             publicProfileEnabled: true,
             boostCredits: 0,
             createdAt: serverTimestamp(),
+            developerMode: false,
           };
           await setDoc(ref, data);
           try {
@@ -255,6 +258,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }): ReactElemen
       const snap = await getDoc(ref);
       const newData = snap.data() as Profile;
       if (newData.publicProfileEnabled === undefined) newData.publicProfileEnabled = true;
+      if (newData.developerMode === undefined) newData.developerMode = false;
       setProfile(newData);
     } catch (err) {
       console.error('Failed to update profile', err);


### PR DESCRIPTION
## Summary
- reorganize wish posting form into Advanced Options
- show support & boost info on wish cards
- enable developer analytics dashboard in settings
- track developer mode in user profile

## Testing
- `npm test`
- `npm run lint` *(shows warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688aab44ef5c83278339c207fd32410c