### PR TITLE
Fix onboarding redirect path

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,8 +18,8 @@ function LayoutInner() {
   useEffect(() => {
     const check = async () => {
       const seen = await AsyncStorage.getItem('hasSeenOnboarding');
-      if (!seen && pathname !== '/onboarding') {
-        router.replace('/onboarding');
+      if (!seen && pathname !== '/Onboarding') {
+        router.replace('/Onboarding');
       }
     };
     check();


### PR DESCRIPTION
## Summary
- use `/Onboarding` route when redirecting first-time users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688babe82d6c83278bc44476c4472e88