### PR TITLE
Temporarily disable onboarding redirect

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,8 @@ function LayoutInner() {
     const check = async () => {
       const seen = await AsyncStorage.getItem('hasSeenOnboarding');
       if (!seen && pathname !== '/onboarding') {
-        router.replace('/onboarding');
+        // Temporarily bypass onboarding for testing purposes
+        // router.replace('/onboarding');
       }
     };
     check();


### PR DESCRIPTION
## Summary
- stop automatic redirect to `/onboarding` so the main app can be tested

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5460ebe08327a9254c849a60fcf0