### PR TITLE
Add Ionicons import in settings screen

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,6 +3,8 @@ import ThemedButton from '@/components/ThemedButton';
 import { useTheme, ThemeName } from '@/contexts/ThemeContext';
 import { Colors } from '@/constants/Colors';
 import { useAuth } from '@/contexts/AuthContext';
+// Ionicons is used for the collapsible section chevrons
+import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   ScrollView,


### PR DESCRIPTION
## Summary
- import Ionicons from `@expo/vector-icons` in `settings.tsx`
- ensure collapsible section chevrons render correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bb605d07c8327b44f67d9b4963036