### PR TITLE
Add legal docs and require acceptance

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,9 @@
+# Privacy Policy
+
+We respect your privacy and collect only the information needed to operate WhispList.
+
+- **Account Data**: When you sign up we store your email address and any profile information you provide in Firebase. You may choose to remain anonymous.
+- **Wishes and Comments**: Content you post is stored securely in Firebase until you delete it.
+- **Analytics**: We use anonymous analytics to understand app usage. This data does not identify you personally.
+- **Payments**: Gift transactions are processed by Stripe or external links. We never store your payment details.
+- **Your Choices**: You can export or delete your data at any time from the settings screen. For questions contact support@example.com.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Join our community of developers creating universal apps.
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
 
+## Legal
+
+New users must accept our [Terms of Service](TERMS.md) and [Privacy Policy](PRIVACY.md) during onboarding.
+
 ## Audio support
 
 `expo-av` has been deprecated in favor of the new [`expo-audio`](https://docs.expo.dev/versions/latest/sdk/audio/) library.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,22 @@
+# Terms of Service
+
+1. **Acceptance of Terms**
+By creating an account or using WhispList you agree to these Terms of Service and our Privacy Policy.
+
+2. **Use of the Service**
+You may post wishes and comments for personal, non-commercial use. Do not post illegal, abusive or infringing content.
+
+3. **Accounts**
+You are responsible for maintaining the confidentiality of your account credentials. You may delete your account at any time.
+
+4. **Content Ownership**
+You retain ownership of content you post. You grant WhispList a license to display your content within the app and related services.
+
+5. **Termination**
+We may suspend or terminate accounts that violate these terms or applicable law.
+
+6. **Disclaimer**
+The service is provided "as is" without warranties of any kind. We are not liable for any damages arising from your use of WhispList.
+
+7. **Changes to Terms**
+We may update these Terms from time to time. Continued use of the service after changes constitutes acceptance of the new Terms.

--- a/app/Onboarding.tsx
+++ b/app/Onboarding.tsx
@@ -33,6 +33,7 @@ export default function Page() {
   const { theme } = useTheme();
   const [index, setIndex] = useState(0);
   const [completed, setCompleted] = useState(false);
+  const [accepted, setAccepted] = useState(false);
   const viewConfigRef = useRef({ viewAreaCoveragePercentThreshold: 50 });
   const scrollX = useRef(new Animated.Value(0)).current;
 
@@ -52,6 +53,7 @@ export default function Page() {
     if (completed) return;
     setCompleted(true);
     await AsyncStorage.setItem('hasSeenOnboarding', 'true');
+    await AsyncStorage.setItem('acceptedTerms', 'true');
     trackEvent('complete_onboarding');
     router.replace('/');
   };
@@ -120,12 +122,48 @@ export default function Page() {
         })}
       </View>
       {index === slides.length - 1 && (
-        <ThemedButton
-          title="Get Started"
-          onPress={handleDone}
-          accessibilityLabel="Get Started"
-          accessibilityRole="button"
-        />
+        <>
+          <View style={styles.acceptRow}>
+            <TouchableOpacity
+              onPress={() => setAccepted(!accepted)}
+              style={[
+                styles.checkbox,
+                {
+                  backgroundColor: accepted ? theme.tint : 'transparent',
+                  borderColor: theme.text,
+                },
+              ]}
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked: accepted }}
+            />
+            <Text
+              onPress={() => setAccepted(!accepted)}
+              style={[styles.acceptText, { color: theme.text }]}
+            >
+              I agree to the
+              <Text
+                onPress={() => router.push('/terms')}
+                style={{ textDecorationLine: 'underline' }}
+              >
+                {' Terms of Service '}
+              </Text>
+              and
+              <Text
+                onPress={() => router.push('/privacy')}
+                style={{ textDecorationLine: 'underline' }}
+              >
+                {' Privacy Policy'}
+              </Text>
+            </Text>
+          </View>
+          <ThemedButton
+            title="Get Started"
+            onPress={handleDone}
+            disabled={!accepted}
+            accessibilityLabel="Get Started"
+            accessibilityRole="button"
+          />
+        </>
       )}
     </View>
   );
@@ -173,6 +211,25 @@ const styles = StyleSheet.create({
     height: 8,
     borderRadius: 4,
     marginHorizontal: 4,
+  },
+  acceptRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+    paddingHorizontal: 10,
+  },
+  checkbox: {
+    width: 20,
+    height: 20,
+    borderWidth: 2,
+    borderRadius: 4,
+    marginRight: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  acceptText: {
+    flex: 1,
+    fontSize: 14,
   },
 });
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,7 +18,8 @@ function LayoutInner() {
   useEffect(() => {
     const check = async () => {
       const seen = await AsyncStorage.getItem('hasSeenOnboarding');
-      if (!seen && pathname !== '/Onboarding') {
+      const accepted = await AsyncStorage.getItem('acceptedTerms');
+      if ((!seen || !accepted) && pathname !== '/Onboarding') {
         router.replace('/Onboarding');
       }
     };

--- a/app/privacy.tsx
+++ b/app/privacy.tsx
@@ -8,12 +8,33 @@ export default function PrivacyScreen() {
       <Text style={{ color: theme.text, fontSize: 20, fontWeight: 'bold', marginBottom: 10 }}>
         Privacy Policy
       </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        We respect your privacy and collect only the information needed to
+        operate WhispList.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        • <Text style={{ fontWeight: 'bold' }}>Account Data</Text> – When you
+        sign up we store your email address and any profile details you provide
+        in Firebase. You may choose to remain anonymous.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        • <Text style={{ fontWeight: 'bold' }}>Wishes and Comments</Text> –
+        Content you post is stored securely in Firebase until you delete it.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        • <Text style={{ fontWeight: 'bold' }}>Analytics</Text> – We use
+        anonymous analytics to understand app usage. This data does not identify
+        you personally.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        • <Text style={{ fontWeight: 'bold' }}>Payments</Text> – Gift
+        transactions are processed by Stripe or external links. We never store
+        your payment details.
+      </Text>
       <Text style={{ color: theme.text }}>
-        We store your wishes and optional profile information securely in
-        Firebase. Guest posts stay on your device unless you sign up. Google
-        login shares your public profile and email with us for account recovery.
-        Gift transactions are processed by Stripe or external links and we never
-        see your payment details.
+        • <Text style={{ fontWeight: 'bold' }}>Your Choices</Text> – You can
+        export or delete your data at any time from the settings screen. Contact
+        support@example.com with any questions.
       </Text>
     </ScrollView>
   );

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -8,12 +8,40 @@ export default function TermsScreen() {
       <Text style={{ color: theme.text, fontSize: 20, fontWeight: 'bold', marginBottom: 10 }}>
         Terms of Service
       </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        1. <Text style={{ fontWeight: 'bold' }}>Acceptance of Terms</Text> – By
+        creating an account or using WhispList you agree to these Terms of
+        Service and our Privacy Policy.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        2. <Text style={{ fontWeight: 'bold' }}>Use of the Service</Text> – You
+        may post wishes and comments for personal, non‑commercial use. Do not
+        post illegal, abusive or infringing content.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        3. <Text style={{ fontWeight: 'bold' }}>Accounts</Text> – You are
+        responsible for keeping your credentials confidential. You may delete
+        your account at any time.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        4. <Text style={{ fontWeight: 'bold' }}>Content Ownership</Text> – You
+        retain ownership of content you post. You grant WhispList a license to
+        display your content within the app and related services.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        5. <Text style={{ fontWeight: 'bold' }}>Termination</Text> – We may
+        suspend or terminate accounts that violate these terms or applicable
+        law.
+      </Text>
+      <Text style={{ color: theme.text, marginBottom: 10 }}>
+        6. <Text style={{ fontWeight: 'bold' }}>Disclaimer</Text> – The service
+        is provided "as is" without warranties of any kind. We are not liable
+        for any damages arising from your use of WhispList.
+      </Text>
       <Text style={{ color: theme.text }}>
-        By using WhispList you agree to post only content you have the right to
-        share. You may remain anonymous; however, abusive or illegal activity may
-        result in removal. Boosts and gifts are handled through third‑party
-        providers and are non‑refundable. We do not sell your personal data and
-        you can delete your account at any time.
+        7. <Text style={{ fontWeight: 'bold' }}>Changes to Terms</Text> – We may
+        update these Terms from time to time. Continued use of the service after
+        changes constitutes acceptance of the new Terms.
       </Text>
     </ScrollView>
   );

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -58,6 +58,7 @@ interface Profile {
   giftsReceived?: number;
   referralDisplayName?: string;
   developerMode?: boolean;
+  acceptedTermsAt?: any;
 }
 
 interface AuthContextValue {
@@ -138,8 +139,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }): ReactElemen
           }
           if (data.boostCredits === undefined) data.boostCredits = 0;
           if (data.developerMode === undefined) data.developerMode = false;
+          if (!data.acceptedTermsAt) {
+            const accepted = await AsyncStorage.getItem('acceptedTerms');
+            if (accepted) {
+              const ts = serverTimestamp();
+              await updateDoc(ref, { acceptedTermsAt: ts });
+              data.acceptedTermsAt = ts as any;
+            }
+          }
           setProfile(data);
         } else {
+          const accepted = await AsyncStorage.getItem('acceptedTerms');
+          const ts = serverTimestamp();
           const data: Profile = {
             displayName: u.displayName,
             email: u.email,
@@ -150,6 +161,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }): ReactElemen
             boostCredits: 0,
             createdAt: serverTimestamp(),
             developerMode: false,
+            acceptedTermsAt: accepted ? ts : undefined,
           };
           await setDoc(ref, data);
           try {


### PR DESCRIPTION
## Summary
- add formal Terms of Service and Privacy Policy docs
- expand privacy and terms screens with full text
- ask users to agree to terms during onboarding
- persist acceptance and block app use until accepted
- save acceptance timestamp in user profiles
- document the new requirement in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bb98e844c83278519a27bb6a0c1f0