### PR TITLE
Fix Firebase analytics initialization

### DIFF
--- a/helpers/analytics.ts
+++ b/helpers/analytics.ts
@@ -1,5 +1,10 @@
-import * as Analytics from 'expo-firebase-analytics';
+import { logEvent } from 'firebase/analytics';
+import { analytics } from '../firebase';
 
 export function trackEvent(name: string, params?: Record<string, any>) {
-  Analytics.logEvent(name, params);
+  if (analytics) {
+    logEvent(analytics, name, params);
+  } else {
+    console.warn('Analytics not ready');
+  }
 }


### PR DESCRIPTION
## Summary
- initialize analytics safely using Firebase modular SDK
- guard logEvent calls if analytics is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bbd5847a88327a82b072ea911bbff