### PR TITLE
Fix firestore rules for anonymous journal access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -20,7 +20,8 @@ service cloud.firestore {
       }
 
       match /journalEntries/{entryId} {
-        allow read, write: if request.auth.uid == uid;
+        // Allow signed-in (including anonymous) users to read/write their own journal entries
+        allow read, write: if signedIn() && request.auth.uid == uid;
       }
 
       match /followers/{followerId} {


### PR DESCRIPTION
## Summary
- update `/journalEntries` rule to require signed-in users but allow anonymous accounts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bc1dfeaf88327b1b495f5ec21645c