### PR TITLE
Fix profile page permission errors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -25,7 +25,7 @@ service cloud.firestore {
       }
 
       match /followers/{followerId} {
-        allow read, write: if request.auth.uid == followerId;
+        allow read, write: if request.auth.uid == followerId || request.auth.uid == uid;
       }
 
       match /following/{targetUserId} {
@@ -65,6 +65,7 @@ service cloud.firestore {
 
     match /gifts/{giftId} {
       allow write: if signedIn();
+      allow read: if signedIn();
     }
 
     // Referral records for tracking invites


### PR DESCRIPTION
## Summary
- update firestore rules so users can read their follower counts
- allow authenticated read access to root gifts collection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc2cc37148327acf0122e8ce9849d