### PR TITLE
Fix Firestore notification read rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,7 +12,8 @@ service cloud.firestore {
       allow create, update, delete: if request.auth != null && request.auth.uid == uid;
 
       match /notifications/{notificationId} {
-        allow write: if request.auth.uid == uid;
+        // Users can read their own notifications and mark them as read
+        allow read, write: if request.auth.uid == uid;
       }
 
       match /referrals/{referralId} {


### PR DESCRIPTION
## Summary
- allow users to read their notification subcollection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc43bafd8832790a71fed83fec3d8