### PR TITLE
Fix Podfile for iOS build

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ require File.join(File.dirname(`node --print "require.resolve('expo/package.json
 ENV["PODFILE_PROPERTIES"] ||= File.expand_path("../Podfile.properties.json", __dir__)
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
-platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '13.0'
 install! 'cocoapods',
   :deterministic_uuids => false
 
@@ -55,24 +55,33 @@ target 'WhispList' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  post_install do |installer|
-    react_native_post_install(
-      installer,
-      config[:reactNativePath],
-      :mac_catalyst_enabled => false,
-      :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
-    )
+    post_install do |installer|
+      react_native_post_install(
+        installer,
+        config[:reactNativePath],
+        :mac_catalyst_enabled => false,
+        :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
+      )
 
 
-    # This is necessary for Xcode 14, because it signs resource bundles by default
-    # when building for devices.
-    installer.target_installation_results.pod_target_installation_results
-      .each do |pod_name, target_installation_result|
-      target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
-        resource_bundle_target.build_configurations.each do |config|
-          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+      # This is necessary for Xcode 14, because it signs resource bundles by default
+      # when building for devices.
+      installer.target_installation_results.pod_target_installation_results
+        .each do |pod_name, target_installation_result|
+        target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+          resource_bundle_target.build_configurations.each do |config|
+            config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+          end
+        end
+      end
+
+      # Disable modules for react runtime pods to avoid redefinition errors
+      installer.pods_project.targets.each do |target|
+        if ['React-RuntimeApple', 'React-RCTRuntime'].include?(target.name)
+          target.build_configurations.each do |config|
+            config.build_settings['DEFINES_MODULE'] = 'NO'
+          end
         end
       end
     end
   end
-end


### PR DESCRIPTION
## Summary
- set ios platform to 13.0
- turn off DEFINES_MODULE for React-RuntimeApple and React-RCTRuntime

## Testing
- `pod install --repo-update --allow-root` *(fails: Invalid `Podfile` file: No such file or directory - xcodebuild)*
- `npx expo run:ios` *(fails: iOS apps can only be built on macOS devices)*

------
https://chatgpt.com/codex/tasks/task_e_688bd4bca29c83279ebf6102d86633d0