### PR TITLE
Fix theme colors for dialogs and pages

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,9 +1,11 @@
 import { Text, View } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
 export default function Page() {
+  const { theme } = useTheme();
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>404 - Not Found</Text>
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme.background }}>
+      <Text style={{ color: theme.text }}>404 - Not Found</Text>
     </View>
   );
 }

--- a/app/auth/index.tsx
+++ b/app/auth/index.tsx
@@ -67,14 +67,14 @@ export default function Page() {
       <TextInput
         style={[styles.input, { backgroundColor: theme.input, color: theme.text }]}
         placeholder="Email"
-        placeholderTextColor="#888"
+        placeholderTextColor={theme.text + '99'} // theme fix
         value={email}
         onChangeText={setEmail}
       />
       <TextInput
         style={[styles.input, { backgroundColor: theme.input, color: theme.text }]}
         placeholder="Password"
-        placeholderTextColor="#888"
+        placeholderTextColor={theme.text + '99'} // theme fix
         secureTextEntry
         value={password}
         onChangeText={setPassword}

--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -172,9 +172,9 @@ export default function BoostPage() {
           )}
           <TouchableOpacity onPress={handleBoost} style={styles.button} disabled={loading || alreadyBoosted}>
             {loading ? (
-              <ActivityIndicator color="#000" />
+              <ActivityIndicator color={theme.text} />
             ) : (
-              <Text style={styles.buttonText}>Boost 🚀</Text>
+              <Text style={[styles.buttonText, { color: theme.text }]}>Boost 🚀</Text>
             )}
           </TouchableOpacity>
           {alreadyBoosted && (
@@ -202,7 +202,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   buttonText: {
-    color: '#000',
     fontWeight: '600',
   },
   modalOverlay: {

--- a/app/inbox.tsx
+++ b/app/inbox.tsx
@@ -14,8 +14,8 @@ export default function InboxPage() {
 
   const renderItem = ({ item }: any) => (
     <View style={[styles.item, { backgroundColor: theme.input }]}>
-      <Text style={styles.text}>{item.message}</Text>
-      <Text style={styles.time}>
+      <Text style={[styles.text, { color: theme.text }]}>{item.message}</Text>
+      <Text style={[styles.time, { color: theme.text + '99' }]}> // theme fix
         {item.timestamp?.seconds
           ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), { addSuffix: true })
           : 'just now'}
@@ -36,6 +36,6 @@ export default function InboxPage() {
 
 const styles = StyleSheet.create({
   item: { padding: 12, borderRadius: 10, marginBottom: 10 },
-  text: { fontSize: 14, color: '#fff' },
-  time: { fontSize: 12, color: '#888', marginTop: 4 },
+  text: { fontSize: 14 },
+  time: { fontSize: 12, marginTop: 4 },
 });

--- a/app/journal.tsx
+++ b/app/journal.tsx
@@ -244,7 +244,7 @@ export default function JournalPage() {
         ref={inputRef}
         style={[styles.input, { backgroundColor: theme.input, color: theme.text }]}
         placeholder="Write your thoughts"
-        placeholderTextColor="#888"
+        placeholderTextColor={theme.text + '99'} // theme fix
         value={entry}
         onChangeText={setEntry}
         multiline
@@ -268,7 +268,7 @@ export default function JournalPage() {
                   ? item.text.slice(0, 80) + '...'
                   : item.text}
             </Text>
-            <Text style={styles.entryDate}>
+            <Text style={[styles.entryDate, { color: theme.text + '99' }]}> // theme fix
               {item.timestamp?.seconds
                 ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), { addSuffix: true })
                 : 'Just now'}
@@ -304,7 +304,7 @@ const styles = StyleSheet.create({
   buttonText: { fontWeight: '600' },
   entryItem: { marginBottom: 12 },
   entryText: { fontSize: 14 },
-  entryDate: { fontSize: 12, color: '#888' },
+  entryDate: { fontSize: 12 },
   row: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
   summary: { textAlign: 'center', marginBottom: 10 },
 });

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -24,10 +24,10 @@ export default function NotificationsPage() {
 
   const renderItem = ({ item }: { item: Item }) => (
     <View style={[styles.item, { backgroundColor: theme.input }]}>
-      <Text style={styles.text}>
+      <Text style={[styles.text, { color: theme.text }]}> // theme fix
         {item.type === 'wish_boosted' ? '🚀' : item.type === 'new_comment' ? '💬' : '🎉'} {item.message}
       </Text>
-      <Text style={styles.time}>
+      <Text style={[styles.time, { color: theme.text + '99' }]}> // theme fix
         {item.timestamp?.seconds
           ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), { addSuffix: true })
           : 'just now'}
@@ -48,6 +48,6 @@ export default function NotificationsPage() {
 
 const styles = StyleSheet.create({
   item: { padding: 12, borderRadius: 10, marginBottom: 10 },
-  text: { fontSize: 14, color: '#fff' },
-  time: { fontSize: 12, color: '#888', marginTop: 4 },
+  text: { fontSize: 14 },
+  time: { fontSize: 12, marginTop: 4 },
 });

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -61,8 +61,8 @@ import type { Wish } from '../../types/Wish';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackEvent } from '@/helpers/analytics';
 
-const typeInfo: Record<string, { emoji: string; color: string }> = {
-  wish: { emoji: '💭', color: '#1e1e1e' },
+const baseTypeInfo = {
+  wish: { emoji: '💭', color: '#333333' },
   confession: { emoji: '😶\u200d🌫️', color: '#374151' },
   advice: { emoji: '🧠', color: '#064e3b' },
   dream: { emoji: '🌙', color: '#312e81' },
@@ -91,6 +91,10 @@ export default function Page() {
   const { id } = useLocalSearchParams();
   const router = useRouter();
   const { theme } = useTheme();
+  const typeInfo = React.useMemo(() => ({
+    ...baseTypeInfo,
+    wish: { emoji: '💭', color: theme.input },
+  }), [theme]);
   const [wish, setWish] = useState<Wish | null>(null);
   const [comment, setComment] = useState('');
   const [comments, setComments] = useState<Comment[]>([]);
@@ -484,19 +488,19 @@ try {
                 onPress={() => router.push(`/profile/${item.displayName}`)}
                 hitSlop={HIT_SLOP}
               >
-                <Text style={styles.nickname}>
+                <Text style={[styles.nickname, { color: theme.text + '99' }]}> // theme fix
                   {item.displayName}
                   {verifiedStatus[item.userId || ''] ? ' \u2705 Verified' : ''}
                 </Text>
               </TouchableOpacity>
             ) : (
-              <Text style={styles.nickname}>{item.nickname || 'Anonymous'}</Text>
+              <Text style={[styles.nickname, { color: theme.text + '99' }]}>{item.nickname || 'Anonymous'}</Text>
             )}
             {item.userId === wish?.userId && (
-              <Text style={[styles.nickname, { color: '#a78bfa' }]}> (author)</Text>
+              <Text style={[styles.nickname, { color: theme.tint }]}> (author)</Text>
             )}
-            <Text style={styles.comment}>{item.text}</Text>
-            <Text style={styles.timestamp}>
+            <Text style={[styles.comment, { color: theme.text }]}>{item.text}</Text>
+            <Text style={[styles.timestamp, { color: theme.text + '99' }]}> // theme fix
               {item.timestamp?.seconds
                 ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), { addSuffix: true })
                 : 'Just now'}
@@ -559,7 +563,7 @@ try {
         </TouchableOpacity>
 
 {loading ? (
-  <ActivityIndicator size="large" color="#a78bfa" style={{ marginTop: 20 }} />
+  <ActivityIndicator size="large" color={theme.tint} style={{ marginTop: 20 }} /> // theme fix
 ) : error ? (
   <Text style={styles.errorText}>{error}</Text>
 ) : (
@@ -582,9 +586,7 @@ try {
         </Text>
         <Text style={[styles.wishText, { color: theme.text }]}>{wish.text}</Text>
         {wish.fulfillmentLink && (
-          <Text style={{ color: '#34d399', marginTop: 4 }}>
-            💝 Fulfilled
-          </Text>
+          <Text style={{ color: theme.tint, marginTop: 4 }}>💝 Fulfilled</Text>
         )}
         {wish.imageUrl && (
           <Image source={{ uri: wish.imageUrl }} style={styles.preview} />
@@ -637,11 +639,11 @@ try {
               yAxisSuffix=""
               fromZero
               chartConfig={{
-                backgroundColor: '#1e1e1e',
-                backgroundGradientFrom: '#1e1e1e',
-                backgroundGradientTo: '#1e1e1e',
-                color: () => '#a78bfa',
-                labelColor: () => '#ccc',
+                backgroundColor: theme.input,
+                backgroundGradientFrom: theme.input,
+                backgroundGradientTo: theme.input,
+                color: () => theme.tint,
+                labelColor: () => theme.text + '99',
               }}
               style={{ marginTop: 10 }}
             />
@@ -774,44 +776,44 @@ try {
               })()}
             </Text>
             <TouchableOpacity onPress={() => setReplyTo(null)} style={{ marginLeft: 8 }}>
-              <Text style={{ color: '#fff' }}>Cancel</Text>
+              <Text style={{ color: theme.text }}>Cancel</Text>
             </TouchableOpacity>
           </View>
         )}
 
-        <Text style={styles.label}>Comment</Text>
+        <Text style={[styles.label, { color: theme.text + '99' }]}>Comment</Text>
         <TextInput
-          style={styles.input}
+          style={[styles.input, { backgroundColor: theme.input, color: theme.text }]}
           placeholder="Your comment"
-          placeholderTextColor="#aaa"
+          placeholderTextColor={theme.text + '99'} // theme fix
           value={comment}
           onChangeText={setComment}
         />
         {!useProfileComment && (
           <TextInput
-            style={styles.input}
+            style={[styles.input, { backgroundColor: theme.input, color: theme.text }]}
             placeholder="Nickname or emoji"
-            placeholderTextColor="#aaa"
+            placeholderTextColor={theme.text + '99'} // theme fix
             value={nickname}
             onChangeText={setNickname}
           />
         )}
 
         <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
-          <Text style={{ color: '#fff', marginRight: 8 }}>Comment with profile</Text>
+          <Text style={{ color: theme.text, marginRight: 8 }}>Comment with profile</Text>
           <Switch value={useProfileComment} onValueChange={setUseProfileComment} />
         </View>
 
         <TouchableOpacity
-          style={styles.button}
+          style={[styles.button, { backgroundColor: theme.tint }]}
           onPress={handlePostComment}
           disabled={postingComment}
           hitSlop={HIT_SLOP}
         >
           {postingComment ? (
-            <ActivityIndicator color="#fff" />
+            <ActivityIndicator color={theme.text} />
           ) : (
-            <Text style={styles.buttonText}>Send Comment</Text>
+            <Text style={[styles.buttonText, { color: theme.text }]}>Send Comment</Text>
           )}
         </TouchableOpacity>
         <ReportDialog
@@ -831,15 +833,15 @@ try {
             }}
             style={{ marginTop: 8 }}
           >
-            <Text style={{ color: '#34d399' }}>View Fulfillment Link</Text>
+            <Text style={{ color: theme.tint }}>View Fulfillment Link</Text>
           </TouchableOpacity>
         ) : (
           <TouchableOpacity
-            style={styles.button}
+            style={[styles.button, { backgroundColor: theme.tint }]}
             onPress={() => setFulfillmentVisible(true)}
             hitSlop={HIT_SLOP}
           >
-            <Text style={styles.buttonText}>Fulfill this Wish</Text>
+            <Text style={[styles.buttonText, { color: theme.text }]}>Fulfill this Wish</Text>
           </TouchableOpacity>
         )}
 
@@ -874,13 +876,13 @@ try {
                       }
                       setConfirmGift(null);
                     }}
-                    style={[styles.button, { marginRight: 8 }]}
+                    style={[styles.button, { backgroundColor: theme.tint, marginRight: 8 }]}
                     hitSlop={HIT_SLOP}
                   >
                     <Text style={styles.buttonText}>Send</Text>
                   </TouchableOpacity>
-                  <TouchableOpacity onPress={() => setConfirmGift(null)} style={[styles.button, { backgroundColor: '#ccc' }]} hitSlop={HIT_SLOP}>
-                    <Text style={[styles.buttonText, { color: '#000' }]}>Cancel</Text>
+                  <TouchableOpacity onPress={() => setConfirmGift(null)} style={[styles.button, { backgroundColor: theme.input }]} hitSlop={HIT_SLOP}>
+                    <Text style={[styles.buttonText, { color: theme.text }]}>Cancel</Text>
                   </TouchableOpacity>
                 </View>
               </View>
@@ -893,9 +895,9 @@ try {
               <View style={[styles.modalCard, { backgroundColor: theme.input }]}>
                 <Text style={[styles.modalText, { color: theme.text }]}>💝 Thanks for supporting this wish!</Text>
                 <TextInput
-                  style={[styles.input, { marginTop: 10 }]}
+                  style={[styles.input, { marginTop: 10, backgroundColor: theme.input, color: theme.text }]}
                   placeholder="Add a message (optional)"
-                  placeholderTextColor="#999"
+                  placeholderTextColor={theme.text + '99'} // theme fix
                   value={thanksMessage}
                   onChangeText={setThanksMessage}
                 />
@@ -914,14 +916,14 @@ try {
                       setThanksMessage('');
                       setShowThanks(false);
                     }}
-                    style={[styles.button, { marginTop: 10 }]}
+                    style={[styles.button, { backgroundColor: theme.tint, marginTop: 10 }]}
                     hitSlop={HIT_SLOP}
                   >
-                    <Text style={styles.buttonText}>Send</Text>
+                    <Text style={[styles.buttonText, { color: theme.text }]}>Send</Text>
                   </TouchableOpacity>
                 )}
-                <TouchableOpacity onPress={() => setShowThanks(false)} style={[styles.button, { marginTop: 10 }]} hitSlop={HIT_SLOP}>
-                  <Text style={styles.buttonText}>Close</Text>
+                <TouchableOpacity onPress={() => setShowThanks(false)} style={[styles.button, { backgroundColor: theme.tint, marginTop: 10 }]} hitSlop={HIT_SLOP}>
+                  <Text style={[styles.buttonText, { color: theme.text }]}>Close</Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -1003,26 +1005,20 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   nickname: {
-    color: '#ccc',
     fontSize: 12,
     marginBottom: 2,
   },
   comment: {
-    color: '#fff',
     fontSize: 14,
   },
   timestamp: {
-    color: '#666',
     fontSize: 10,
     marginTop: 4,
   },
   label: {
-    color: '#ccc',
     marginBottom: 4,
   },
   input: {
-    backgroundColor: '#1e1e1e',
-    color: '#fff',
     padding: 12,
     borderRadius: 10,
     marginBottom: 10,
@@ -1033,14 +1029,12 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   button: {
-    backgroundColor: '#8b5cf6',
     padding: 14,
     borderRadius: 10,
     alignItems: 'center',
     marginTop: 10,
   },
   buttonText: {
-    color: '#fff',
     fontWeight: '600',
   },
   modalBackdrop: {

--- a/components/FulfillmentLinkDialog.tsx
+++ b/components/FulfillmentLinkDialog.tsx
@@ -43,9 +43,9 @@ export default function FulfillmentLinkDialog({ visible, onClose, onSubmit, exis
           <TextInput
             style={styles.input}
             placeholder="Paste fulfillment link"
-            placeholderTextColor="#888"
-          value={link}
-          onChangeText={setLink}
+            placeholderTextColor={theme.text + '99'} // theme fix
+            value={link}
+            onChangeText={setLink}
         />
         {error ? <Text style={styles.error}>{error}</Text> : null}
         <View style={styles.buttons}>

--- a/components/ReferralNameDialog.tsx
+++ b/components/ReferralNameDialog.tsx
@@ -28,7 +28,7 @@ export default function ReferralNameDialog({ visible, defaultName = '', onClose,
           <TextInput
             style={styles.input}
             placeholder="Name or handle"
-            placeholderTextColor="#888"
+            placeholderTextColor={c.text + '99'} // theme fix
             value={name}
             onChangeText={setName}
           />

--- a/components/ReportDialog.tsx
+++ b/components/ReportDialog.tsx
@@ -27,7 +27,7 @@ export default function ReportDialog({ visible, onClose, onSubmit }: ReportDialo
           <TextInput
             style={styles.input}
             placeholder="Reason for report"
-            placeholderTextColor="#888"
+            placeholderTextColor={c.text + '99'} // theme fix
             value={reason}
             onChangeText={setReason}
           />


### PR DESCRIPTION
## Summary
- ensure modals use themed placeholder text
- adjust inbox and notifications to respect theme colors
- update journal screen placeholders and timestamps
- theme error and placeholder colors across wish detail and boost screens
- add theme support on the 404 screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bddc786c483279fdbf0c9ee8cbf9a