### PR TITLE
fix: use React Native Firebase auth persistence

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -1,11 +1,9 @@
 import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { getReactNativePersistence } from 'firebase/auth/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
+// React Native auth entrypoint
+import { initializeAuth, getReactNativePersistence } from 'firebase/auth/react-native';
 import { getAnalytics, isSupported, Analytics } from 'firebase/analytics';
 
 const firebaseConfig = {
@@ -20,7 +18,8 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 
-export const auth = (getAuth as any)(app, {
+// Initialize Auth for React Native with AsyncStorage persistence
+export const auth = initializeAuth(app, {
   persistence: getReactNativePersistence(AsyncStorage),
 });
 export const db = getFirestore(app);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
-    "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "@react-native-picker/picker": "^2.11.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
@@ -42,7 +42,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.8",
     "expo-web-browser": "~14.2.0",
-    "firebase": "^11.9.1",
+    "firebase": "^11.0.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.4",


### PR DESCRIPTION
## Summary
- ensure firebase v11 and React Native async storage dependencies
- initialize Firebase auth using React Native persistence API

## Testing
- `npm install`
- `npx expo start -c`

------
https://chatgpt.com/codex/tasks/task_e_68955dffe8b083279c7cc3de04221bdd