### PR TITLE
fix firebase auth import for react native

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -2,8 +2,7 @@ import { initializeApp } from 'firebase/app';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
-// eslint-disable-next-line import/no-unresolved
-import { initializeAuth, getReactNativePersistence } from 'firebase/auth/react-native';
+import { initializeAuth, getReactNativePersistence } from 'firebase/auth';
 import { getAnalytics, isSupported, Analytics } from 'firebase/analytics';
 
 const firebaseConfig = {

--- a/types/firebase-auth-react-native.d.ts
+++ b/types/firebase-auth-react-native.d.ts
@@ -1,1 +1,8 @@
-declare module 'firebase/auth/react-native';
+export {};
+
+declare module 'firebase/auth' {
+  import type { Persistence, ReactNativeAsyncStorage } from '@firebase/auth';
+  export function getReactNativePersistence(
+    storage: ReactNativeAsyncStorage,
+  ): Persistence;
+}


### PR DESCRIPTION
## Summary
- fix firebase auth import to use react-native compatible entry
- add TypeScript declaration for `getReactNativePersistence`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689565a79e80832786993ca1565c0ee9