### PR TITLE
chore: ignore vscode settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ npm-debug.*
 yarn-debug.*
 yarn-error.*
 
+# editors
+.vscode/
+
 # macOS
 .DS_Store
 *.pem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "source.organizeImports": "explicit",
-    "source.sortMembers": "explicit"
-  }
-}


### PR DESCRIPTION
## Summary
- ignore `.vscode/` directory in git
- remove tracked VS Code settings

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689573d3c5048327a1f6df3619f77c23