### PR TITLE
chore: validate firebase env vars

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -6,6 +6,22 @@ import { getAuth, initializeAuth, getReactNativePersistence } from 'firebase/aut
 import { getAnalytics, isSupported, Analytics } from 'firebase/analytics';
 import { Platform } from 'react-native';
 
+const requiredEnvVars = [
+  'EXPO_PUBLIC_FIREBASE_API_KEY',
+  'EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN',
+  'EXPO_PUBLIC_FIREBASE_PROJECT_ID',
+  'EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET',
+  'EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+  'EXPO_PUBLIC_FIREBASE_APP_ID',
+  'EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID',
+];
+
+requiredEnvVars.forEach((name) => {
+  if (!process.env[name]) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+});
+
 const firebaseConfig = {
   apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,


### PR DESCRIPTION
## Summary
- fail fast if Firebase env vars are missing

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689575ac9e8c832791287c589021f6d2