### PR TITLE
refactor: modularize firestore helpers

### DIFF
--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -20,11 +20,11 @@ import ReportDialog from '../../components/ReportDialog';
 import WishCardComponent from '../../components/WishCard';
 import {
   listenTrendingWishes,
-  getFollowingIds,
   listenBoostedWishes,
   getTopBoostedCreators,
   getWhispOfTheDay,
-} from '../../helpers/firestore';
+} from '../../helpers/wishes';
+import { getFollowingIds } from '../../helpers/followers';
 import {
   addDoc,
   collection,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,12 +5,14 @@ import { createRecorder, type AudioRecorder } from 'expo-audio';
 import * as ExpoAudio from 'expo-audio';
 import {
   addWish,
+  createGiftCheckout,
+  cleanupExpiredWishes,
+} from '../../helpers/wishes';
+import {
   getFollowingIds,
   followUser,
   unfollowUser,
-  createGiftCheckout,
-  cleanupExpiredWishes,
-} from '../../helpers/firestore';
+} from '../../helpers/followers';
 import { formatTimeLeft } from '../../helpers/time';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -43,11 +43,8 @@ import {
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import React, { useEffect, useState } from 'react';
 import { db, storage } from '../../firebase';
-import {
-  getAllWishes,
-  getWishComments,
-  getWishesByNickname,
-} from '../../helpers/firestore';
+import { getAllWishes, getWishesByNickname } from '../../helpers/wishes';
+import { getWishComments } from '../../helpers/comments';
 
 export default function Page() {
   const { theme, setTheme } = useTheme();

--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -16,7 +16,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import * as Linking from 'expo-linking';
-import { getWish, boostWish } from '../../helpers/firestore';
+import { getWish, boostWish } from '../../helpers/wishes';
 import { formatTimeLeft } from '../../helpers/time';
 
 export default function BoostPage() {

--- a/app/journal.tsx
+++ b/app/journal.tsx
@@ -21,7 +21,7 @@ import {
   orderBy,
   getDocs,
 } from 'firebase/firestore';
-import { addWish } from '../helpers/firestore';
+import { addWish } from '../helpers/wishes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { db } from '../firebase';

--- a/app/profile/[displayName].tsx
+++ b/app/profile/[displayName].tsx
@@ -25,7 +25,7 @@ import * as Linking from 'expo-linking';
 import { formatDistanceToNow } from 'date-fns';
 import { formatTimeLeft } from '../../helpers/time';
 import { db } from '../../firebase';
-import { followUser, unfollowUser } from '../../helpers/firestore';
+import { followUser, unfollowUser } from '../../helpers/followers';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Colors } from '@/constants/Colors';

--- a/app/profile/[username].tsx
+++ b/app/profile/[username].tsx
@@ -22,7 +22,7 @@ import {
 } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { db } from '../../firebase';
-import { followUser, unfollowUser } from '../../helpers/firestore';
+import { followUser, unfollowUser } from '../../helpers/followers';
 import { useAuth } from '@/contexts/AuthContext';
 import type { Wish } from '../../types/Wish';
 

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -7,12 +7,15 @@ import { Ionicons } from '@expo/vector-icons';
 import { createPlayer, type AudioPlayer } from 'expo-audio';
 import {
   getWish,
+  setFulfillmentLink,
+  createGiftCheckout,
+} from '../../helpers/wishes';
+import {
   listenWishComments,
   addComment,
   updateCommentReaction,
-  setFulfillmentLink,
-  createGiftCheckout,
-} from '../../helpers/firestore';
+  type Comment,
+} from '../../helpers/comments';
 
 import {
   addDoc,
@@ -77,20 +80,6 @@ const formatTimeLeft = (d: Date) => {
   const m = Math.floor((ms % 3_600_000) / 60_000);
   return `${h}h ${m}m`;
 };
-
-interface Comment {
-  id: string;
-  text: string;
-  userId?: string;
-  displayName?: string;
-  photoURL?: string;
-  isAnonymous?: boolean;
-  timestamp?: any;
-  parentId?: string;
-  reactions?: Record<string, number>;
-  userReactions?: Record<string, string>;
-  nickname?: string;
-}
 
 const emojiOptions = ['❤️', '😂', '😢', '👍'];
 // Approximate height of a single comment item including margins

--- a/components/WishCard.tsx
+++ b/components/WishCard.tsx
@@ -12,7 +12,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { Ionicons } from '@expo/vector-icons';
 import { useSavedWishes } from '@/contexts/SavedWishesContext';
 import type { Wish } from '../types/Wish';
-import { updateWishReaction } from '../helpers/firestore';
+import { updateWishReaction } from '../helpers/wishes';
 import { db } from '../firebase';
 import { collection, getDocs, doc, onSnapshot } from 'firebase/firestore';
 import { formatTimeLeft } from '../helpers/time';

--- a/helpers/comments.ts
+++ b/helpers/comments.ts
@@ -1,0 +1,102 @@
+import {
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  addDoc,
+  serverTimestamp,
+  doc,
+  getDoc,
+  updateDoc,
+  getDocs,
+} from 'firebase/firestore';
+import { db } from '../firebase';
+
+export interface Comment {
+  id: string;
+  text: string;
+  userId?: string;
+  displayName?: string;
+  photoURL?: string;
+  isAnonymous?: boolean;
+  timestamp?: any;
+  parentId?: string;
+  reactions?: Record<string, number>;
+  userReactions?: Record<string, string>;
+  nickname?: string;
+  [key: string]: any;
+}
+
+export function listenWishComments(
+  wishId: string,
+  cb: (comments: Comment[]) => void,
+) {
+  const q = query(
+    collection(db, 'wishes', wishId, 'comments'),
+    orderBy('timestamp', 'asc'),
+  );
+  return onSnapshot(q, (snap) => {
+    const data = snap.docs.map((d) => ({
+      id: d.id,
+      ...(d.data() as Omit<Comment, 'id'>),
+    }));
+    cb(data as Comment[]);
+  });
+}
+
+export async function addComment(wishId: string, data: Omit<Comment, 'id'>) {
+  return addDoc(collection(db, 'wishes', wishId, 'comments'), {
+    timestamp: serverTimestamp(),
+    ...data,
+  });
+}
+
+export async function updateCommentReaction(
+  wishId: string,
+  commentId: string,
+  emoji: string,
+  prevEmoji: string | undefined,
+  user: string,
+) {
+  const ref = doc(db, 'wishes', wishId, 'comments', commentId);
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return;
+  const data = snap.data() as Comment;
+  const reactions = { ...(data.reactions || {}) } as Record<string, number>;
+  const userReactions = { ...(data.userReactions || {}) } as Record<
+    string,
+    string
+  >;
+
+  if (prevEmoji && reactions[prevEmoji]) {
+    reactions[prevEmoji] -= 1;
+    if (reactions[prevEmoji] === 0) delete reactions[prevEmoji];
+  }
+
+  if (prevEmoji === emoji) {
+    delete userReactions[user];
+  } else {
+    userReactions[user] = emoji;
+    reactions[emoji] = (reactions[emoji] || 0) + 1;
+  }
+
+  return updateDoc(ref, { reactions, userReactions });
+}
+
+export async function getWishComments(wishId: string): Promise<Comment[]> {
+  const snap = await getDocs(collection(db, 'wishes', wishId, 'comments'));
+  return snap.docs.map((d) => {
+    const data = d.data();
+    const comment: Comment = {
+      id: d.id,
+      text: data.text,
+      nickname: data.nickname,
+      timestamp: data.timestamp,
+      parentId: data.parentId,
+      reactions: data.reactions,
+      userReactions: data.userReactions,
+    };
+    return comment;
+  });
+}
+

--- a/helpers/followers.ts
+++ b/helpers/followers.ts
@@ -1,0 +1,79 @@
+import {
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  doc,
+  setDoc,
+  deleteDoc,
+  serverTimestamp,
+  getDocs,
+  where,
+  limit,
+} from 'firebase/firestore';
+import { db } from '../firebase';
+import type { Wish } from '../types/Wish';
+
+export async function followUser(currentUser: string, targetUser: string) {
+  const followerRef = doc(db, 'users', targetUser, 'followers', currentUser);
+  const followingRef = doc(db, 'users', currentUser, 'following', targetUser);
+  await Promise.all([
+    setDoc(followerRef, { createdAt: serverTimestamp() }),
+    setDoc(followingRef, { createdAt: serverTimestamp() }),
+  ]);
+}
+
+export async function unfollowUser(currentUser: string, targetUser: string) {
+  const followerRef = doc(db, 'users', targetUser, 'followers', currentUser);
+  const followingRef = doc(db, 'users', currentUser, 'following', targetUser);
+  await Promise.all([deleteDoc(followerRef), deleteDoc(followingRef)]);
+}
+
+export async function getFollowingIds(userId: string): Promise<string[]> {
+  const q = query(collection(db, 'users', userId, 'following'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => d.id);
+}
+
+export function listenFollowingWishes(
+  userId: string,
+  cb: (wishes: Wish[]) => void,
+) {
+  let unsub = () => {};
+  getFollowingIds(userId).then((ids) => {
+    if (ids.length === 0) {
+      cb([]);
+      return;
+    }
+    const q = query(
+      collection(db, 'wishes'),
+      where('userId', 'in', ids),
+      orderBy('timestamp', 'desc'),
+    );
+    unsub = onSnapshot(q, (snap) => {
+      const data = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as Omit<Wish, 'id'>),
+      }));
+      cb(data as Wish[]);
+    });
+  });
+  return () => unsub();
+}
+
+export async function getFollowingWishes(userId: string): Promise<Wish[]> {
+  const ids = await getFollowingIds(userId);
+  if (ids.length === 0) return [];
+  const q = query(
+    collection(db, 'wishes'),
+    where('userId', 'in', ids),
+    orderBy('timestamp', 'desc'),
+    limit(20),
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({
+    id: d.id,
+    ...(d.data() as Omit<Wish, 'id'>),
+  })) as Wish[];
+}
+

--- a/helpers/wishes.ts
+++ b/helpers/wishes.ts
@@ -18,19 +18,12 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import type { Wish } from '../types/Wish';
+import { getFollowingIds } from './followers';
 
-export interface Comment {
-  id: string;
-  text: string;
-  userId?: string;
-  displayName?: string;
-  photoURL?: string;
-  isAnonymous?: boolean;
-  timestamp?: any;
-  parentId?: string;
-  reactions?: Record<string, number>;
-  userReactions?: Record<string, string>;
-  [key: string]: any;
+export interface TopCreator {
+  userId: string;
+  displayName: string;
+  count: number;
 }
 
 export function listenTrendingWishes(cb: (wishes: Wish[]) => void) {
@@ -118,75 +111,9 @@ export function listenBoostedWishes(cb: (wishes: Wish[]) => void) {
   });
 }
 
-export async function followUser(currentUser: string, targetUser: string) {
-  const followerRef = doc(db, 'users', targetUser, 'followers', currentUser);
-  const followingRef = doc(db, 'users', currentUser, 'following', targetUser);
-  await Promise.all([
-    setDoc(followerRef, { createdAt: serverTimestamp() }),
-    setDoc(followingRef, { createdAt: serverTimestamp() }),
-  ]);
-}
-
-export async function unfollowUser(currentUser: string, targetUser: string) {
-  const followerRef = doc(db, 'users', targetUser, 'followers', currentUser);
-  const followingRef = doc(db, 'users', currentUser, 'following', targetUser);
-  await Promise.all([deleteDoc(followerRef), deleteDoc(followingRef)]);
-}
-
-export async function getFollowingIds(userId: string): Promise<string[]> {
-  const q = query(collection(db, 'users', userId, 'following'));
-  const snap = await getDocs(q);
-  return snap.docs.map((d) => d.id);
-}
-
-export function listenFollowingWishes(
-  userId: string,
-  cb: (wishes: Wish[]) => void,
-) {
-  let unsub = () => {};
-  getFollowingIds(userId).then((ids) => {
-    if (ids.length === 0) {
-      cb([]);
-      return;
-    }
-    const q = query(
-      collection(db, 'wishes'),
-      where('userId', 'in', ids),
-      orderBy('timestamp', 'desc'),
-    );
-    unsub = onSnapshot(q, (snap) => {
-      const data = snap.docs.map((d) => ({
-        id: d.id,
-        ...(d.data() as Omit<Wish, 'id'>),
-      }));
-      cb(data as Wish[]);
-    });
-  });
-  return () => unsub();
-}
-
-export async function getFollowingWishes(userId: string): Promise<Wish[]> {
-  const ids = await getFollowingIds(userId);
-  if (ids.length === 0) return [];
-  const q = query(
-    collection(db, 'wishes'),
-    where('userId', 'in', ids),
-    orderBy('timestamp', 'desc'),
-  );
-  const snap = await getDocs(q);
-  return snap.docs.map((d) => ({
-    id: d.id,
-    ...(d.data() as Omit<Wish, 'id'>),
-  })) as Wish[];
-}
-
-export async function getTopBoostedCreators(limitCount = 5): Promise<
-  {
-    userId: string;
-    displayName: string;
-    count: number;
-  }[]
-> {
+export async function getTopBoostedCreators(
+  limitCount = 5,
+): Promise<TopCreator[]> {
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
   const q = query(collection(db, 'wishes'), where('boostedUntil', '>=', since));
   const snap = await getDocs(q);
@@ -225,8 +152,7 @@ export async function getWhispOfTheDay(): Promise<Wish | null> {
       w.boostedUntil.toDate() > new Date();
     const reacts =
       !!w.reactions &&
-      Object.values(w.reactions).reduce<number>((sum, v) => sum + (v ?? 0), 0) >
-        0;
+      Object.values(w.reactions).reduce<number>((sum, v) => sum + (v ?? 0), 0) > 0;
     return boost || reacts;
   });
   if (filtered.length === 0) return null;
@@ -317,62 +243,6 @@ export async function getWish(id: string): Promise<Wish | null> {
     : null;
 }
 
-export function listenWishComments(
-  wishId: string,
-  cb: (comments: Comment[]) => void,
-) {
-  const q = query(
-    collection(db, 'wishes', wishId, 'comments'),
-    orderBy('timestamp', 'asc'),
-  );
-  return onSnapshot(q, (snap) => {
-    const data = snap.docs.map((d) => ({
-      id: d.id,
-      ...(d.data() as Omit<Comment, 'id'>),
-    }));
-    cb(data as Comment[]);
-  });
-}
-
-export async function addComment(wishId: string, data: Omit<Comment, 'id'>) {
-  return addDoc(collection(db, 'wishes', wishId, 'comments'), {
-    timestamp: serverTimestamp(),
-    ...data,
-  });
-}
-
-export async function updateCommentReaction(
-  wishId: string,
-  commentId: string,
-  emoji: string,
-  prevEmoji: string | undefined,
-  user: string,
-) {
-  const ref = doc(db, 'wishes', wishId, 'comments', commentId);
-  const snap = await getDoc(ref);
-  if (!snap.exists()) return;
-  const data = snap.data() as Comment;
-  const reactions = { ...(data.reactions || {}) } as Record<string, number>;
-  const userReactions = { ...(data.userReactions || {}) } as Record<
-    string,
-    string
-  >;
-
-  if (prevEmoji && reactions[prevEmoji]) {
-    reactions[prevEmoji] -= 1;
-    if (reactions[prevEmoji] === 0) delete reactions[prevEmoji];
-  }
-
-  if (prevEmoji === emoji) {
-    delete userReactions[user];
-  } else {
-    userReactions[user] = emoji;
-    reactions[emoji] = (reactions[emoji] || 0) + 1;
-  }
-
-  return updateDoc(ref, { reactions, userReactions });
-}
-
 export async function getWishesByNickname(nickname: string): Promise<Wish[]> {
   const snap = await getDocs(
     query(collection(db, 'wishes'), where('nickname', '==', nickname)),
@@ -459,26 +329,10 @@ export async function getAllWishes(): Promise<Wish[]> {
   return wishes;
 }
 
-export async function getWishComments(wishId: string): Promise<Comment[]> {
-  const snap = await getDocs(collection(db, 'wishes', wishId, 'comments'));
-  return snap.docs.map((d) => {
-    const data = d.data();
-    const comment: Comment = {
-      id: d.id,
-      text: data.text,
-      nickname: data.nickname,
-      timestamp: data.timestamp,
-      parentId: data.parentId,
-      reactions: data.reactions,
-      userReactions: data.userReactions,
-    };
-    return comment;
-  });
-}
-
 export async function cleanupExpiredWishes() {
   const now = new Date();
   const q = query(collection(db, 'wishes'), where('expiresAt', '<=', now));
   const snap = await getDocs(q);
   await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
 }
+


### PR DESCRIPTION
## Summary
- split monolithic firestore helper into wishes, comments, and followers modules
- update imports across app to use new helpers
- expose typed interfaces for comments and top creators

## Testing
- `npm test`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6895795408508327b033f999799df887