### PR TITLE
refactor: use Firestore timestamps

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,6 +30,7 @@ import {
   collectionGroup,
   limit,
   startAfter,
+  Timestamp,
 } from 'firebase/firestore';
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { Ionicons } from '@expo/vector-icons';
@@ -565,7 +566,9 @@ export default function Page() {
         ...(audioUrl && { audioUrl }),
         ...(imageUrl && { imageUrl }),
         ...(autoDelete && {
-          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          expiresAt: Timestamp.fromDate(
+            new Date(Date.now() + 24 * 60 * 60 * 1000),
+          ),
         }),
       });
 
@@ -694,9 +697,7 @@ export default function Page() {
     (wish) =>
       wish.text.toLowerCase().includes(searchTerm.toLowerCase()) &&
       (filterType === 'all' || wish.type === filterType) &&
-      (!wish.expiresAt ||
-        (wish.expiresAt.toDate ? wish.expiresAt.toDate() : wish.expiresAt) >
-          new Date()),
+      (!wish.expiresAt || wish.expiresAt.toDate() > new Date()),
   );
 
   const WishCard: React.FC<{ item: Wish }> = ({ item }) => {
@@ -731,9 +732,9 @@ export default function Page() {
     }, [item.id]);
 
     useEffect(() => {
-      if (isBoosted && item.boostedUntil?.toDate) {
+      if (isBoosted && item.boostedUntil) {
         const update = () =>
-          setTimeLeft(formatTimeLeft(item.boostedUntil.toDate()));
+          setTimeLeft(formatTimeLeft(item.boostedUntil!.toDate()));
         update();
         const id = setInterval(update, 60000);
         const loop = Animated.loop(
@@ -770,9 +771,7 @@ export default function Page() {
     const canBoost =
       user &&
       item.userId === user.uid &&
-      (!item.boostedUntil ||
-        !item.boostedUntil.toDate ||
-        item.boostedUntil.toDate() < new Date());
+      (!item.boostedUntil || item.boostedUntil.toDate() < new Date());
 
     const openGiftLink = (link: string) => {
       Alert.alert(

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -128,11 +128,7 @@ export default function Page() {
         ...(d.data() as Omit<Wish, 'id'>),
       })) as Wish[];
       const more = mapped.filter(
-        (w) =>
-          !w.expiresAt ||
-          ((w.expiresAt as any).toDate
-            ? (w.expiresAt as any).toDate()
-            : w.expiresAt) > new Date(),
+        (w) => !w.expiresAt || w.expiresAt.toDate() > new Date(),
       );
       setPostedList((prev) => [...prev, ...more]);
       setError(null);
@@ -160,11 +156,7 @@ export default function Page() {
           ...(d.data() as Omit<Wish, 'id'>),
         })) as Wish[];
         const list = mapped.filter(
-          (w) =>
-            !w.expiresAt ||
-            ((w.expiresAt as any).toDate
-              ? (w.expiresAt as any).toDate()
-              : w.expiresAt) > new Date(),
+          (w) => !w.expiresAt || w.expiresAt.toDate() > new Date(),
         );
         setPostedList(list);
         setError(null);
@@ -175,10 +167,10 @@ export default function Page() {
             w.boostedUntil.toDate() > new Date(),
         );
         setBoostCount(active.length);
-        if (active.length > 0) {
-          active.sort((a, b) =>
-            a.boostedUntil.toDate() < b.boostedUntil.toDate() ? 1 : -1,
-          );
+          if (active.length > 0) {
+            active.sort((a, b) =>
+              a.boostedUntil!.toDate() < b.boostedUntil!.toDate() ? 1 : -1,
+            );
           setLatestBoost(active[0]);
         } else {
           setLatestBoost(null);

--- a/app/profile/[displayName].tsx
+++ b/app/profile/[displayName].tsx
@@ -200,9 +200,9 @@ export default function Page() {
             item.boostedUntil &&
             item.boostedUntil.toDate &&
             item.boostedUntil.toDate() > new Date();
-          const timeLeft = isBoosted
-            ? formatTimeLeft(item.boostedUntil.toDate())
-            : '';
+            const timeLeft = isBoosted
+              ? formatTimeLeft(item.boostedUntil!.toDate())
+              : '';
           return (
             <View style={[styles.wishItem, { backgroundColor: theme.input }]}>
               <Text style={styles.categoryText}>

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -146,15 +146,15 @@ export default function Page() {
   const isActiveWish =
     isBoosted || (wish?.likes || 0) > 5 || wish?.active === true;
   const [timeLeft, setTimeLeft] = useState(
-    isBoosted && wish?.boostedUntil?.toDate
-      ? formatTimeLeft(wish.boostedUntil.toDate())
+    isBoosted && wish?.boostedUntil
+      ? formatTimeLeft(wish.boostedUntil!.toDate())
       : '',
   );
   const glowAnim = useRef(new Animated.Value(0)).current;
   useEffect(() => {
-    if (isBoosted && wish?.boostedUntil?.toDate) {
+    if (isBoosted && wish?.boostedUntil) {
       const update = () =>
-        setTimeLeft(formatTimeLeft(wish.boostedUntil.toDate()));
+        setTimeLeft(formatTimeLeft(wish.boostedUntil!.toDate()));
       update();
       const id = setInterval(update, 60000);
       const loop = Animated.loop(

--- a/components/WishCard.tsx
+++ b/components/WishCard.tsx
@@ -101,16 +101,16 @@ export const WishCard: React.FC<{
     return unsub;
   }, [user?.uid, wish.id]);
 
-  useEffect(() => {
-    if (!isBoosted || !wish.boostedUntil?.toDate) {
-      setTimeLeft('');
-      glowAnim.setValue(0);
-      return;
-    }
-    const update = () =>
-      setTimeLeft(formatTimeLeft(wish.boostedUntil.toDate()));
-    update();
-    const id = setInterval(update, 60000);
+    useEffect(() => {
+      if (!isBoosted || !wish.boostedUntil) {
+        setTimeLeft('');
+        glowAnim.setValue(0);
+        return;
+      }
+      const update = () =>
+        setTimeLeft(formatTimeLeft(wish.boostedUntil!.toDate()));
+      update();
+      const id = setInterval(update, 60000);
     const loop = Animated.loop(
       Animated.sequence([
         Animated.timing(glowAnim, {
@@ -130,7 +130,7 @@ export const WishCard: React.FC<{
       clearInterval(id);
       loop.stop();
     };
-  }, [isBoosted, wish.boostedUntil, glowAnim]);
+    }, [isBoosted, wish.boostedUntil, glowAnim]);
 
   const borderColor =
     moodColors[wish.mood || ''] || typeColors[wish.type || ''] || theme.tint;
@@ -256,9 +256,7 @@ export const WishCard: React.FC<{
         <Text style={{ color: theme.tint, marginTop: 4 }}>
           ⏳{' '}
           {(() => {
-            const ts = wish.expiresAt.toDate
-              ? wish.expiresAt.toDate()
-              : new Date(wish.expiresAt);
+            const ts = wish.expiresAt.toDate();
             const diff = ts.getTime() - Date.now();
             const hrs = Math.max(0, Math.ceil(diff / 3600000));
             return `${hrs}h left`;

--- a/helpers/comments.ts
+++ b/helpers/comments.ts
@@ -9,6 +9,7 @@ import {
   getDoc,
   updateDoc,
   getDocs,
+  Timestamp,
 } from 'firebase/firestore';
 import { db } from '../firebase';
 
@@ -19,7 +20,7 @@ export interface Comment {
   displayName?: string;
   photoURL?: string;
   isAnonymous?: boolean;
-  timestamp?: any;
+  timestamp?: Timestamp | null;
   parentId?: string;
   reactions?: Record<string, number>;
   userReactions?: Record<string, string>;
@@ -44,7 +45,10 @@ export function listenWishComments(
   });
 }
 
-export async function addComment(wishId: string, data: Omit<Comment, 'id'>) {
+export async function addComment(
+  wishId: string,
+  data: Omit<Comment, 'id' | 'timestamp'>,
+) {
   return addDoc(collection(db, 'wishes', wishId, 'comments'), {
     timestamp: serverTimestamp(),
     ...data,

--- a/helpers/wishes.ts
+++ b/helpers/wishes.ts
@@ -15,6 +15,7 @@ import {
   where,
   setDoc,
   deleteDoc,
+  Timestamp,
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import type { Wish } from '../types/Wish';
@@ -199,7 +200,9 @@ export async function updateWishReaction(
 
 export async function boostWish(id: string, hours: number) {
   const ref = doc(db, 'wishes', id);
-  const boostedUntil = new Date(Date.now() + hours * 60 * 60 * 1000);
+  const boostedUntil = Timestamp.fromDate(
+    new Date(Date.now() + hours * 60 * 60 * 1000),
+  );
   return updateDoc(ref, { boostedUntil });
 }
 

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -6,6 +6,7 @@ import {
   orderBy,
   updateDoc,
   doc,
+  Timestamp,
 } from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthContext';
 import { db } from '../firebase';
@@ -14,7 +15,7 @@ export interface NotificationItem {
   id: string;
   type: string;
   message: string;
-  timestamp: any;
+  timestamp: Timestamp | null;
   read?: boolean;
 }
 

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -1,3 +1,5 @@
+import type { Timestamp } from 'firebase/firestore';
+
 export interface Wish {
   id: string;
   text: string;
@@ -11,7 +13,7 @@ export interface Wish {
   displayName?: string;
   photoURL?: string;
   isAnonymous?: boolean;
-  boostedUntil?: any;
+  boostedUntil?: Timestamp | null;
   boosted?: string;
   audioUrl?: string;
   imageUrl?: string;
@@ -50,6 +52,6 @@ export interface Wish {
   /**
    * Timestamp when this wish should disappear
    */
-  expiresAt?: any;
+  expiresAt?: Timestamp | null;
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- replace `any` with `Timestamp | null` for notification and comment timestamps
- model `Wish` expiration/boost fields as Firestore `Timestamp`
- update components to convert `Timestamp` values with `toDate()`

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6895f307955883278a966da83a3f8964