### PR TITLE
refactor: centralize profile types

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -28,6 +28,7 @@ import {
   collectionGroup,
   limit,
   startAfter,
+  Timestamp,
 } from 'firebase/firestore';
 import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
@@ -49,7 +50,7 @@ export default function Page() {
   >([]);
   const [boostImpact, setBoostImpact] = useState({ likes: 0, comments: 0 });
   const [giftStats, setGiftStats] = useState({ count: 0, total: 0 });
-  const [giftMessages, setGiftMessages] = useState<{ text: string; ts: any }[]>(
+  const [giftMessages, setGiftMessages] = useState<{ text: string; ts: Timestamp }[]>(
     [],
   );
   const [savedList, setSavedList] = useState<Wish[]>([]);
@@ -274,7 +275,7 @@ export default function Page() {
       );
       let count = 0;
       let total = 0;
-      const msgs: { text: string; ts: any }[] = [];
+      const msgs: { text: string; ts: Timestamp }[] = [];
       const ids = new Set<string>();
       snap.forEach((d) => {
         count += 1;

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -45,23 +45,12 @@ import React, { useEffect, useState } from 'react';
 import { db, storage } from '../../firebase';
 import { getAllWishes, getWishesByNickname } from '../../helpers/wishes';
 import { getWishComments } from '../../helpers/comments';
+import type { Profile } from '../../types/Profile';
 
 export default function Page() {
   const { theme, setTheme } = useTheme();
-  type Profile = {
-    displayName?: string;
-    bio?: string;
-    photoURL?: string;
-    publicProfileEnabled?: boolean;
-    giftingEnabled?: boolean;
-    stripeAccountId?: string;
-    referralDisplayName?: string;
-    developerMode?: boolean;
-    boostCredits?: number;
-    isDev?: boolean;
-  };
   const { user, profile: profileData, updateProfile } = useAuth();
-  const profile = profileData as Profile | null;
+  const profile = profileData as (Profile & { isDev?: boolean }) | null;
   const router = useRouter();
 
   const themeOptions = Object.keys(Colors) as ThemeName[];

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -33,32 +33,17 @@ import {
   getDocs,
   query,
   where,
+  Timestamp,
 } from 'firebase/firestore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';
+import type { Profile } from '../types/Profile';
 
 WebBrowser.maybeCompleteAuthSession();
 
 if (!auth || !db || !storage) {
   console.error('Firebase modules are undefined in AuthContext');
-}
-
-interface Profile {
-  displayName: string | null;
-  email: string | null;
-  bio?: string;
-  photoURL?: string | null;
-  isAnonymous: boolean;
-  publicProfileEnabled?: boolean;
-  boostCredits?: number;
-  createdAt?: any;
-  giftingEnabled?: boolean;
-  stripeAccountId?: string;
-  giftsReceived?: number;
-  referralDisplayName?: string;
-  developerMode?: boolean;
-  acceptedTermsAt?: any;
 }
 
 interface AuthContextValue {
@@ -148,7 +133,7 @@ export const AuthProvider = ({
             if (accepted) {
               const ts = serverTimestamp();
               await updateDoc(ref, { acceptedTermsAt: ts });
-              data.acceptedTermsAt = ts as any;
+              data.acceptedTermsAt = ts as unknown as Timestamp;
             }
           }
           setProfile(data);
@@ -163,9 +148,9 @@ export const AuthProvider = ({
             isAnonymous: u.isAnonymous,
             publicProfileEnabled: true,
             boostCredits: 0,
-            createdAt: serverTimestamp(),
+            createdAt: serverTimestamp() as unknown as Timestamp,
             developerMode: false,
-            acceptedTermsAt: accepted ? ts : undefined,
+            acceptedTermsAt: accepted ? (ts as unknown as Timestamp) : undefined,
           };
           await setDoc(ref, data);
           try {

--- a/types/Profile.ts
+++ b/types/Profile.ts
@@ -1,0 +1,18 @@
+import { Timestamp } from 'firebase/firestore';
+
+export interface Profile {
+  displayName: string | null;
+  email: string | null;
+  bio?: string;
+  photoURL?: string | null;
+  isAnonymous: boolean;
+  publicProfileEnabled?: boolean;
+  boostCredits?: number;
+  createdAt?: Timestamp;
+  giftingEnabled?: boolean;
+  stripeAccountId?: string;
+  giftsReceived?: number;
+  referralDisplayName?: string;
+  developerMode?: boolean;
+  acceptedTermsAt?: Timestamp;
+}


### PR DESCRIPTION
## Summary
- centralize `Profile` type definition and replace inline interfaces
- remove `any` timestamp usages in auth and profile logic

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6895f63f692883279a628ddec8b2fbcd