### PR TITLE
Make theme setter asynchronous

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -60,7 +60,7 @@ export default function Page() {
     return (
       <TouchableOpacity
         key={name}
-        onPress={() => setTheme(name)}
+        onPress={() => void setTheme(name)}
         style={[
           styles.themeItem,
           {
@@ -543,7 +543,7 @@ export default function Page() {
             </ScrollView>
             <Picker
               selectedValue={theme.name}
-              onValueChange={(value) => setTheme(value as ThemeName)}
+              onValueChange={(value) => void setTheme(value as ThemeName)}
               style={[
                 styles.picker,
                 { backgroundColor: theme.input, color: theme.text },

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -8,15 +8,15 @@ export type Theme = { name: ThemeName } & (typeof Colors)['light'];
 
 interface ThemeContextValue {
   theme: Theme;
-  setTheme: (themeName: ThemeName) => void;
-  toggleTheme: () => void;
+  setTheme: (themeName: ThemeName) => Promise<void>;
+  toggleTheme: () => Promise<void>;
 }
 
 const defaultTheme: Theme = { name: 'light', ...Colors.light };
 const ThemeContext = createContext<ThemeContextValue>({
   theme: defaultTheme,
-  setTheme: () => {},
-  toggleTheme: () => {},
+  setTheme: async () => {},
+  toggleTheme: async () => {},
 });
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
@@ -37,13 +37,13 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
     load();
   }, [systemTheme]);
 
-  const setTheme = async (val: ThemeName) => {
+  const setTheme = async (val: ThemeName): Promise<void> => {
     setThemeName(val);
     await AsyncStorage.setItem('appTheme', val);
   };
 
-  const toggleTheme = () => {
-    setTheme(themeName === 'light' ? 'dark' : 'light');
+  const toggleTheme = async (): Promise<void> => {
+    await setTheme(themeName === 'light' ? 'dark' : 'light');
   };
 
   const theme: Theme = { name: themeName, ...Colors[themeName] };


### PR DESCRIPTION
## Summary
- Update ThemeContext so setTheme returns a Promise and toggleTheme awaits it
- Adjust settings screen to ignore the Promise returned by setTheme

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6895fcbe49108327b4dbeba0bd74d996