### PR TITLE
Extract ReactionBar component and add tests

### DIFF
--- a/components/ReactionBar.tsx
+++ b/components/ReactionBar.tsx
@@ -1,0 +1,100 @@
+import React, { useRef } from 'react';
+import { View, Text, TouchableOpacity, Animated, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/contexts/ThemeContext';
+import type { Wish } from '../types/Wish';
+
+export const reactionMap = {
+  pray: '🙏',
+  lightbulb: '💡',
+  hug: '🫂',
+  heart: '❤️',
+} as const;
+
+export type ReactionKey = keyof typeof reactionMap;
+
+interface ReactionBarProps {
+  wish: Wish;
+  userReaction: ReactionKey | null;
+  onReact: (key: ReactionKey) => void;
+  onToggleSave: () => void;
+  isSaved: boolean;
+}
+
+export const ReactionBar: React.FC<ReactionBarProps> = ({
+  wish,
+  userReaction,
+  onReact,
+  onToggleSave,
+  isSaved,
+}) => {
+  const { theme } = useTheme();
+  const reactionScales = useRef(
+    (Object.keys(reactionMap) as ReactionKey[]).reduce((acc, k) => {
+      acc[k] = new Animated.Value(1);
+      return acc;
+    }, {} as Record<ReactionKey, Animated.Value>),
+  ).current;
+
+  return (
+    <View style={styles.reactionBar}>
+      {(Object.keys(reactionMap) as ReactionKey[]).map((key) => (
+        <Animated.View key={key} style={{ transform: [{ scale: reactionScales[key] }] }}>
+          <TouchableOpacity
+            testID={`reaction-${key}`}
+            onPressIn={() =>
+              Animated.spring(reactionScales[key], {
+                toValue: 1.2,
+                useNativeDriver: true,
+              }).start()
+            }
+            onPressOut={() =>
+              Animated.spring(reactionScales[key], {
+                toValue: 1,
+                useNativeDriver: true,
+              }).start()
+            }
+            onPress={() => onReact(key)}
+            style={[
+              styles.reactionButton,
+              userReaction === key && { backgroundColor: theme.input },
+            ]}
+          >
+            <Text style={styles.reactionText}>
+              {reactionMap[key]} {wish.reactions?.[key] || 0}
+            </Text>
+          </TouchableOpacity>
+        </Animated.View>
+      ))}
+      <TouchableOpacity
+        testID="save-button"
+        onPress={onToggleSave}
+        style={styles.reactionButton}
+      >
+        <Ionicons
+          name={isSaved ? 'bookmark' : 'bookmark-outline'}
+          size={20}
+          color={theme.tint}
+        />
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  reactionBar: {
+    flexDirection: 'row',
+    marginTop: 8,
+  },
+  reactionButton: {
+    marginRight: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderRadius: 6,
+  },
+  reactionText: {
+    fontSize: 18,
+  },
+});
+
+export default ReactionBar;

--- a/tests/ReactionBar.test.tsx
+++ b/tests/ReactionBar.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import ReactionBar, { ReactionKey } from '@/components/ReactionBar';
+import type { Wish } from '@/types/Wish';
+import { Text, StyleSheet } from 'react-native';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return {
+    Ionicons: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: { tint: '#123', input: '#eee' } }),
+}));
+
+describe('ReactionBar', () => {
+  const wish: Wish = {
+    id: '1',
+    text: 'test',
+    category: 'gen',
+    likes: 0,
+    reactions: { pray: 1, lightbulb: 0, hug: 0, heart: 0 },
+  };
+
+  it('calls onReact when a reaction is pressed', () => {
+    const onReact = jest.fn();
+    const { getByTestId } = render(
+      <ReactionBar
+        wish={wish}
+        userReaction={null}
+        onReact={onReact}
+        onToggleSave={jest.fn()}
+        isSaved={false}
+      />,
+    );
+
+    fireEvent.press(getByTestId('reaction-pray'));
+    expect(onReact).toHaveBeenCalledWith('pray');
+  });
+
+  it('calls onToggleSave when bookmark pressed', () => {
+    const onToggleSave = jest.fn();
+    const { getByTestId } = render(
+      <ReactionBar
+        wish={wish}
+        userReaction={null}
+        onReact={jest.fn()}
+        onToggleSave={onToggleSave}
+        isSaved={false}
+      />,
+    );
+
+    fireEvent.press(getByTestId('save-button'));
+    expect(onToggleSave).toHaveBeenCalled();
+  });
+
+  it('highlights selected reaction', () => {
+    const { getByTestId } = render(
+      <ReactionBar
+        wish={wish}
+        userReaction={'pray' as ReactionKey}
+        onReact={jest.fn()}
+        onToggleSave={jest.fn()}
+        isSaved={false}
+      />,
+    );
+
+    const btn = getByTestId('reaction-pray');
+    const flattened = StyleSheet.flatten(btn.props.style);
+    expect(flattened.backgroundColor).toBe('#eee');
+  });
+});
+


### PR DESCRIPTION
## Summary
- move reaction buttons from WishCard into new ReactionBar component with animations and save toggle
- update WishCard to render ReactionBar and supply reaction handlers
- add unit tests ensuring ReactionBar reactions and bookmark trigger correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960185185c832780899acb2f42acf0