### PR TITLE
refactor: remove index signatures from key types

### DIFF
--- a/constants/url.ts
+++ b/constants/url.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_ALLOWED_HOSTS: string[] = process.env.ALLOWED_HOSTS
   ? process.env.ALLOWED_HOSTS.split(',')
-      .map((h) => h.trim())
+      .map((h: string) => h.trim())
       .filter(Boolean)
   : ['amazon.com', 'gofundme.com', 'venmo.com'];

--- a/helpers/wishes.ts
+++ b/helpers/wishes.ts
@@ -18,7 +18,7 @@ import {
   Timestamp,
 } from 'firebase/firestore';
 import { db } from '../firebase';
-import type { Wish } from '../types/Wish';
+import type { Wish, ReactionType } from '../types/Wish';
 import { getFollowingIds } from './followers';
 
 export interface TopCreator {
@@ -160,7 +160,9 @@ export async function getWhispOfTheDay(): Promise<Wish | null> {
   return filtered[Math.floor(Math.random() * filtered.length)];
 }
 
-export async function addWish(data: Omit<Wish, 'id'>) {
+export async function addWish(
+  data: Omit<Wish, 'id' | 'likes' | 'reactions'>,
+) {
   return addDoc(collection(db, 'wishes'), {
     likes: 0,
     reactions: {
@@ -181,13 +183,13 @@ export async function likeWish(id: string) {
 
 export async function updateWishReaction(
   id: string,
-  emoji: string,
+  emoji: ReactionType,
   user: string,
 ) {
   const wishRef = doc(db, 'wishes', id);
   const reactRef = doc(db, 'reactions', id, 'users', user);
   const snap = await getDoc(reactRef);
-  const prev = snap.exists() ? snap.data().emoji : null;
+  const prev = snap.exists() ? (snap.data().emoji as ReactionType) : null;
   const updates: Record<string, any> = {};
   if (prev) updates[`reactions.${prev}`] = increment(-1);
   if (prev === emoji) {

--- a/types/Wish.ts
+++ b/types/Wish.ts
@@ -1,6 +1,8 @@
 import type { Timestamp } from 'firebase/firestore';
 
-export interface Wish {
+export type ReactionType = 'heart' | 'lightbulb' | 'hug' | 'pray';
+
+export type Wish<Extra extends Record<string, unknown> = {}> = {
   id: string;
   text: string;
   category: string;
@@ -42,16 +44,18 @@ export interface Wish {
   /**
    * Emoji reaction counts
    */
-  reactions?: {
-    heart?: number;
-    lightbulb?: number;
-    hug?: number;
-    pray?: number;
-    [key: string]: number | undefined;
-  };
+  reactions?: Partial<Record<ReactionType, number>>;
   /**
    * Timestamp when this wish should disappear
    */
   expiresAt?: Timestamp | null;
-  [key: string]: any;
-}
+  /**
+   * Timestamp when this wish was created
+   */
+  timestamp?: Timestamp | null;
+  /**
+   * Whether this wish is marked as active
+   */
+  active?: boolean;
+} & Extra;
+


### PR DESCRIPTION
## Summary
- refactor Wish type to enumerate properties and reaction keys
- make comment helpers generic and remove index signatures
- tighten wish reaction updates and comment parent typing

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689607f728788327bd2a85391fd3f079