### PR TITLE
chore: log analytics initialization errors

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -55,6 +55,9 @@ isSupported()
       analytics = getAnalytics(app);
     }
   })
-  .catch(() => {});
+  .catch((error) => {
+    console.warn('Failed to initialize analytics:', error);
+    // TODO: optionally surface this via telemetry so failures are trackable
+  });
 
 export { analytics };


### PR DESCRIPTION
## Summary
- warn when Firebase analytics initialization fails

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68960b0df3648327b71bfd2405350fac