### PR TITLE
feat: surface authentication errors

### DIFF
--- a/app/auth/index.tsx
+++ b/app/auth/index.tsx
@@ -19,52 +19,48 @@ export default function Page() {
     signInWithGoogle,
     signInAnonymously,
     resetPassword,
+    authError,
+    setAuthError,
   } = useAuth();
   const { theme } = useTheme();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [mode, setMode] = useState<'login' | 'signup'>('login');
-  const [error, setError] = useState<string | null>(null);
-
   const handleSubmit = async () => {
+    setAuthError(null);
     try {
       if (mode === 'login') {
         await signIn(email, password);
       } else {
         await signUp(email, password);
       }
-    } catch (err: any) {
-      setError(err.message);
-    }
+    } catch {}
   };
 
   const handleGoogle = async () => {
+    setAuthError(null);
     try {
       await signInWithGoogle();
-    } catch (err: any) {
-      setError(err.message);
-    }
+    } catch {}
   };
 
   const handleGuest = async () => {
+    setAuthError(null);
     try {
       await signInAnonymously();
-    } catch (err: any) {
-      setError(err.message);
-    }
+    } catch {}
   };
 
   const handleResetPassword = async () => {
+    setAuthError(null);
     try {
       if (!email) {
-        setError('Enter your email first');
+        setAuthError('Enter your email first');
         return;
       }
       await resetPassword(email);
       alert('Password reset email sent');
-    } catch (err: any) {
-      setError(err.message);
-    }
+    } catch {}
   };
 
   useEffect(() => {
@@ -78,8 +74,8 @@ export default function Page() {
       <Text style={[styles.title, { color: theme.text }]}>
         {mode === 'login' ? 'Login' : 'Sign Up'}
       </Text>
-      {error && (
-        <Text style={[styles.error, { color: '#f87171' }]}>{error}</Text>
+      {authError && (
+        <Text style={[styles.error, { color: '#f87171' }]}>{authError}</Text>
       )}
       <TextInput
         style={[

--- a/components/AppContainer.tsx
+++ b/components/AppContainer.tsx
@@ -4,17 +4,27 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
 import usePushNotifications from '@/hooks/usePushNotifications';
+import { useAuth } from '@/contexts/AuthContext';
 
 export const AppContainer: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const { theme } = useTheme();
+  const { authError, setAuthError } = useAuth();
   const backgroundColor = theme.background;
   const barStyle =
     theme.name === 'dark' || theme.name === 'neon'
       ? 'light-content'
       : 'dark-content';
   usePushNotifications();
+
+  useEffect(() => {
+    if (authError) {
+      Alert.alert('Authentication Error', authError, [
+        { text: 'OK', onPress: () => setAuthError(null) },
+      ]);
+    }
+  }, [authError, setAuthError]);
 
   useEffect(() => {
     const showQuote = async () => {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -50,6 +50,8 @@ interface AuthContextValue {
   user: User | null;
   profile: Profile | null;
   loading: boolean;
+  authError: string | null;
+  setAuthError: (err: string | null) => void;
   signUp: (email: string, password: string) => Promise<void>;
   signIn: (email: string, password: string) => Promise<void>;
   signInWithGoogle: () => Promise<void>;
@@ -64,6 +66,8 @@ const AuthContext = createContext<AuthContextValue>({
   user: null,
   profile: null,
   loading: true,
+  authError: null,
+  setAuthError: () => {},
   signUp: async () => {},
   signIn: async () => {},
   signInWithGoogle: async () => {},
@@ -82,6 +86,7 @@ export const AuthProvider = ({
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
 
   const [, , promptAsync] = Google.useIdTokenAuthRequest({
     clientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
@@ -150,7 +155,9 @@ export const AuthProvider = ({
             boostCredits: 0,
             createdAt: serverTimestamp() as unknown as Timestamp,
             developerMode: false,
-            acceptedTermsAt: accepted ? (ts as unknown as Timestamp) : undefined,
+            acceptedTermsAt: accepted
+              ? (ts as unknown as Timestamp)
+              : undefined,
           };
           await setDoc(ref, data);
           try {
@@ -194,7 +201,8 @@ export const AuthProvider = ({
     try {
       await createUserWithEmailAndPassword(auth, email, password);
     } catch (err) {
-      console.error('Failed to sign up', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
       throw err;
     }
   };
@@ -203,7 +211,8 @@ export const AuthProvider = ({
     try {
       await signInWithEmailAndPassword(auth, email, password);
     } catch (err) {
-      console.error('Failed to sign in', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
       throw err;
     }
   };
@@ -212,7 +221,8 @@ export const AuthProvider = ({
     try {
       await signInAnonymously(auth);
     } catch (err) {
-      console.error('Failed to sign in anonymously', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
     }
   };
 
@@ -226,7 +236,8 @@ export const AuthProvider = ({
         await signInWithCredential(auth, credential);
       }
     } catch (err) {
-      console.error('Failed to sign in with Google', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
     }
   };
 
@@ -234,7 +245,8 @@ export const AuthProvider = ({
     try {
       await sendPasswordResetEmail(auth, email);
     } catch (err) {
-      console.error('Failed to reset password', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
       throw err;
     }
   };
@@ -243,7 +255,8 @@ export const AuthProvider = ({
     try {
       await fbSignOut(auth);
     } catch (err) {
-      console.error('Failed to sign out', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
     }
   };
 
@@ -265,7 +278,8 @@ export const AuthProvider = ({
       if (newData.developerMode === undefined) newData.developerMode = false;
       setProfile(newData);
     } catch (err) {
-      console.error('Failed to update profile', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
     }
   };
 
@@ -291,7 +305,8 @@ export const AuthProvider = ({
       }
       return undefined;
     } catch (err) {
-      console.error('Failed to pick image', err);
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
       return undefined;
     }
   };
@@ -302,6 +317,8 @@ export const AuthProvider = ({
         user,
         profile,
         loading,
+        authError,
+        setAuthError,
         signUp,
         signIn,
         signInWithGoogle,


### PR DESCRIPTION
## Summary
- track `authError` in authentication context and set on failures
- show sign-in errors on auth page and global alert

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68960c40fc488327baa2205535f9bde1