### PR TITLE
docs: expand env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,32 @@
+# Firebase web API key
 EXPO_PUBLIC_FIREBASE_API_KEY=your-api-key
+# Firebase Auth domain
 EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=your-app.firebaseapp.com
+# Firebase project ID
 EXPO_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+# Firebase storage bucket
 EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=your-app.appspot.com
+# Firebase cloud messaging sender ID
 EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+# Firebase app ID
 EXPO_PUBLIC_FIREBASE_APP_ID=your-app-id
+# Firebase analytics measurement ID
 EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID=your-measurement-id
+# OAuth client ID for Google sign-in (web)
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+# OAuth client ID for Google sign-in (iOS)
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=your-ios-google-client-id
-# calls to OpenAI are proxied through a secure Cloud Function
+
+# Comma-separated list of domains allowed for external links
+ALLOWED_HOSTS=localhost
+
+# Stripe secret key used by Cloud Functions for payments
+STRIPE_SECRET_KEY=your-stripe-secret
+
+# Stripe webhook signing secret to verify events
+STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+
+# OpenAI API key used by Cloud Function to rephrase wishes
+OPENAI_API_KEY=your-openai-api-key
+
+# Calls to OpenAI are proxied through a secure Cloud Function


### PR DESCRIPTION
## Summary
- document all existing env vars in .env.example
- add ALLOWED_HOSTS and Cloud Function keys for Stripe and OpenAI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689610c163ec8327a56f8f0f4274538b