### PR TITLE
refactor auth helpers into services and hooks

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -18,6 +18,7 @@ import * as Linking from 'expo-linking';
 import * as Notifications from 'expo-notifications';
 import { Colors } from '@/constants/Colors';
 import { useAuth } from '@/contexts/AuthContext';
+import { useProfile } from '@/hooks/useProfile';
 import { useTheme } from '@/contexts/ThemeContext';
 import {
   collection,
@@ -35,7 +36,8 @@ import type { Wish } from '../../types/Wish';
 import { useSavedWishes } from '@/contexts/SavedWishesContext';
 
 export default function Page() {
-  const { user, profile, updateProfile, pickImage, signOut } = useAuth();
+  const { user, profile, signOut } = useAuth();
+  const { updateProfile, pickImage } = useProfile();
   const router = useRouter();
   const [displayName, setDisplayName] = useState(profile?.displayName || '');
   const [bio, setBio] = useState(profile?.bio || '');

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,6 +3,7 @@ import ThemedButton from '@/components/ThemedButton';
 import { useTheme, ThemeName } from '@/contexts/ThemeContext';
 import { Colors } from '@/constants/Colors';
 import { useAuth } from '@/contexts/AuthContext';
+import { useProfile } from '@/hooks/useProfile';
 // Ionicons is used for the collapsible section chevrons
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -49,7 +50,8 @@ import type { Profile } from '../../types/Profile';
 
 export default function Page() {
   const { theme, setTheme } = useTheme();
-  const { user, profile: profileData, updateProfile } = useAuth();
+  const { user, profile: profileData } = useAuth();
+  const { updateProfile } = useProfile();
   const profile = profileData as (Profile & { isDev?: boolean }) | null;
   const router = useRouter();
 

--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -13,6 +13,7 @@ import {
   Modal,
 } from 'react-native';
 import { useAuth } from '@/contexts/AuthContext';
+import { useProfile } from '@/hooks/useProfile';
 import { useTheme } from '@/contexts/ThemeContext';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import * as Linking from 'expo-linking';
@@ -21,7 +22,8 @@ import { formatTimeLeft } from '../../helpers/time';
 
 export default function BoostPage() {
   const { id } = useLocalSearchParams<{ id: string }>();
-  const { user, profile, updateProfile } = useAuth();
+  const { user, profile } = useAuth();
+  const { updateProfile } = useProfile();
   const router = useRouter();
   const { theme } = useTheme();
   const [loading, setLoading] = useState(false);

--- a/hooks/useProfile.ts
+++ b/hooks/useProfile.ts
@@ -1,0 +1,68 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { db, storage } from '../firebase';
+import {
+  doc,
+  updateDoc,
+  getDoc,
+} from 'firebase/firestore';
+import { updateProfile as fbUpdateProfile } from 'firebase/auth';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import * as ImagePicker from 'expo-image-picker';
+import type { Profile } from '../types/Profile';
+
+export const useProfile = () => {
+  const { user, setAuthError, setProfile } = useAuth();
+
+  const updateProfile = async (data: Partial<Profile>) => {
+    try {
+      if (!user) return;
+      const refDoc = doc(db, 'users', user.uid);
+      await updateDoc(refDoc, data);
+      if (data.displayName || data.photoURL) {
+        await fbUpdateProfile(user, {
+          displayName: data.displayName ?? user.displayName ?? undefined,
+          photoURL: data.photoURL ?? user.photoURL ?? undefined,
+        });
+      }
+      const snap = await getDoc(refDoc);
+      const newData = snap.data() as Profile;
+      if (newData.publicProfileEnabled === undefined)
+        newData.publicProfileEnabled = true;
+      if (newData.developerMode === undefined) newData.developerMode = false;
+      setProfile(newData);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
+    }
+  };
+
+  const pickImage = async () => {
+    try {
+      const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!granted) return;
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        quality: 0.7,
+      });
+      if (!result.canceled && result.assets.length > 0) {
+        const asset = result.assets[0];
+        if (!user) return;
+        const storageRef = ref(storage, `profiles/${user.uid}`);
+        const resp = await fetch(asset.uri);
+        const blob = await resp.blob();
+        await uploadBytes(storageRef, blob);
+        const url = await getDownloadURL(storageRef);
+        await updateProfile({ photoURL: url });
+        return url;
+      }
+      return undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setAuthError(message);
+      return undefined;
+    }
+  };
+
+  return { updateProfile, pickImage };
+};
+

--- a/hooks/useReferral.ts
+++ b/hooks/useReferral.ts
@@ -1,0 +1,64 @@
+import * as Linking from 'expo-linking';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  updateDoc,
+  increment,
+  setDoc,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { db } from '../firebase';
+
+export const useReferral = () => {
+  const checkInvite = async () => {
+    try {
+      const url = await Linking.getInitialURL();
+      if (url) {
+        const parsed = Linking.parse(url);
+        const ref = parsed.queryParams?.ref as string | undefined;
+        if (ref) {
+          await AsyncStorage.setItem('inviteRef', ref);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to parse initial URL', err);
+    }
+  };
+
+  const processReferral = async (userId: string) => {
+    try {
+      const inviteRef = await AsyncStorage.getItem('inviteRef');
+      if (inviteRef) {
+        const q = query(
+          collection(db, 'users'),
+          where('displayName', '==', inviteRef),
+        );
+        const res = await getDocs(q);
+        if (!res.empty) {
+          const referrerId = res.docs[0].id;
+          await updateDoc(doc(db, 'users', referrerId), {
+            boostCredits: increment(1),
+          });
+          await updateDoc(doc(db, 'users', userId), { boostCredits: increment(1) });
+          await setDoc(doc(db, 'referrals', userId), {
+            referrerId,
+            referrerDisplayName:
+              res.docs[0].data().referralDisplayName ||
+              res.docs[0].data().displayName,
+            timestamp: serverTimestamp(),
+          });
+        }
+        await AsyncStorage.removeItem('inviteRef');
+      }
+    } catch (err) {
+      console.error('Failed to process referral', err);
+    }
+  };
+
+  return { checkInvite, processReferral };
+};
+

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -1,0 +1,35 @@
+import { auth } from '../firebase';
+import {
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signInAnonymously,
+  signOut as fbSignOut,
+  sendPasswordResetEmail,
+  GoogleAuthProvider,
+  signInWithCredential,
+} from 'firebase/auth';
+import { AuthSessionResult } from 'expo-auth-session';
+
+export const signUp = (email: string, password: string) =>
+  createUserWithEmailAndPassword(auth, email, password);
+
+export const signIn = (email: string, password: string) =>
+  signInWithEmailAndPassword(auth, email, password);
+
+export const signInAnonymouslyService = () => signInAnonymously(auth);
+
+export const resetPassword = (email: string) =>
+  sendPasswordResetEmail(auth, email);
+
+export const signOut = () => fbSignOut(auth);
+
+export const signInWithGoogle = async (
+  promptAsync: () => Promise<AuthSessionResult | void>,
+) => {
+  const res = await promptAsync();
+  if (res && 'type' in res && res.type === 'success' && res.authentication?.idToken) {
+    const credential = GoogleAuthProvider.credential(res.authentication.idToken);
+    await signInWithCredential(auth, credential);
+  }
+};
+


### PR DESCRIPTION
## Summary
- move sign in/up helpers into `services/auth`
- extract referral and profile update logic to dedicated hooks
- streamline `AuthContext` and update components to use new hooks

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68961798f0d08327b562e0fb82ad49b4