### PR TITLE
refactor daily quote into hook with feature flag

### DIFF
--- a/components/AppContainer.tsx
+++ b/components/AppContainer.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { Alert, SafeAreaView, StatusBar, StyleSheet } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
-import usePushNotifications from '@/hooks/usePushNotifications';
 import { useAuth } from '@/contexts/AuthContext';
+import usePushNotifications from '@/hooks/usePushNotifications';
+import useDailyQuote from '@/hooks/useDailyQuote';
 
 export const AppContainer: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -17,6 +17,7 @@ export const AppContainer: React.FC<{ children: React.ReactNode }> = ({
       ? 'light-content'
       : 'dark-content';
   usePushNotifications();
+  useDailyQuote();
 
   useEffect(() => {
     if (authError) {
@@ -26,25 +27,9 @@ export const AppContainer: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [authError, setAuthError]);
 
-  useEffect(() => {
-    const showQuote = async () => {
-      const enabled = await AsyncStorage.getItem('dailyQuote');
-      if (enabled === 'true') {
-        const quotes = [
-          'Believe in yourself!',
-          'Dream big and dare to fail.',
-          'Every day is a second chance.',
-        ];
-        const q = quotes[Math.floor(Math.random() * quotes.length)];
-        Alert.alert('Motivation', q);
-      }
-    };
-    showQuote();
-  }, []);
-
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={[styles.container, { backgroundColor }]}>
+      <SafeAreaView style={[styles.container, { backgroundColor }]}> 
         <StatusBar barStyle={barStyle} />
         {children}
       </SafeAreaView>

--- a/constants/featureFlags.ts
+++ b/constants/featureFlags.ts
@@ -1,0 +1,1 @@
+export const DAILY_QUOTE_ENABLED = true;

--- a/hooks/useDailyQuote.ts
+++ b/hooks/useDailyQuote.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { Alert } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { DAILY_QUOTE_ENABLED } from '@/constants/featureFlags';
+
+const QUOTES = [
+  'Believe in yourself!',
+  'Dream big and dare to fail.',
+  'Every day is a second chance.',
+];
+
+export default function useDailyQuote() {
+  useEffect(() => {
+    const showQuote = async () => {
+      try {
+        const enabled = await AsyncStorage.getItem('dailyQuote');
+        if (DAILY_QUOTE_ENABLED && enabled === 'true') {
+          const q = QUOTES[Math.floor(Math.random() * QUOTES.length)];
+          Alert.alert('Motivation', q);
+        }
+      } catch (err) {
+        console.warn('Failed to load daily quote', err);
+      }
+    };
+
+    showQuote();
+  }, []);
+}
+


### PR DESCRIPTION
## Summary
- extract daily quote alert into `useDailyQuote` hook
- add `DAILY_QUOTE_ENABLED` feature flag
- invoke hook in `AppContainer` instead of inline effect

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68961a0c588c8327bbf30067091a9359