### PR TITLE
feat: centralize logging and mock in tests

### DIFF
--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -40,6 +40,7 @@ import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
+import * as logger from '@/helpers/logger';
 
 const allCategories = [
   'love',
@@ -59,10 +60,10 @@ export default function Page() {
   const router = useRouter();
 
   if (!db) {
-    console.error('Firebase database undefined in feed page');
+    logger.error('Firebase database undefined in feed page');
   }
   if (user === undefined) {
-    console.error('AuthContext returned undefined user');
+    logger.error('AuthContext returned undefined user');
   }
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [filteredWishes, setFilteredWishes] = useState<Wish[]>([]);
@@ -140,12 +141,12 @@ export default function Page() {
           setLeaderboard(topCreators);
           setWhispOfDay(spotlight);
         } catch (err) {
-          console.warn('Failed to load highlights', err);
+          logger.warn('Failed to load highlights', err);
         }
       })();
       return unsubscribe;
     } catch (err) {
-      console.error('Failed to listen for trending wishes', err);
+      logger.error('Failed to listen for trending wishes', err);
       return () => {};
     }
   }, []);
@@ -158,7 +159,7 @@ export default function Page() {
     }
     getFollowingIds(user.uid)
       .then(setFollowingIds)
-      .catch((err) => console.warn('Failed to load following ids', err));
+      .catch((err) => logger.warn('Failed to load following ids', err));
   }, [user]);
 
   const fetchWishes = useCallback(() => {
@@ -208,7 +209,7 @@ export default function Page() {
             });
             setFilteredWishes(filtered);
           } catch (err) {
-            console.error('❌ Failed to load personalized wishes:', err);
+            logger.error('❌ Failed to load personalized wishes:', err);
             setError('Failed to load wishes');
           } finally {
             setLoading(false);
@@ -246,7 +247,7 @@ export default function Page() {
             });
             setFilteredWishes(filtered);
           } catch (err) {
-            console.error('❌ Failed to filter wishes:', err);
+            logger.error('❌ Failed to filter wishes:', err);
             setError('Failed to load wishes');
           } finally {
             setLoading(false);
@@ -277,7 +278,7 @@ export default function Page() {
           });
           setFilteredWishes(filtered);
         } catch (err) {
-          console.error('❌ Failed to load wishes:', err);
+          logger.error('❌ Failed to load wishes:', err);
           setError('Failed to load wishes');
         } finally {
           setLoading(false);
@@ -285,7 +286,7 @@ export default function Page() {
       })();
       return () => {};
     } catch (err) {
-      console.error('❌ Failed to load wishes:', err);
+      logger.error('❌ Failed to load wishes:', err);
       setError('Failed to load wishes');
       setLoading(false);
       return () => {};
@@ -427,7 +428,7 @@ export default function Page() {
         setFilteredWishes(filtered);
       }
     } catch (err) {
-      console.error('❌ Failed to refresh wishes:', err);
+      logger.error('❌ Failed to refresh wishes:', err);
     } finally {
       setRefreshing(false);
     }
@@ -458,7 +459,7 @@ export default function Page() {
       })) as Wish[];
       setFilteredWishes((prev) => [...prev, ...more]);
     } catch (err) {
-      console.error('Failed to load more wishes', err);
+      logger.error('Failed to load more wishes', err);
     }
   }, [lastVisible]);
 
@@ -483,7 +484,7 @@ export default function Page() {
         timestamp: serverTimestamp(),
       });
     } catch (err) {
-      console.error('❌ Failed to submit report:', err);
+      logger.error('❌ Failed to submit report:', err);
     } finally {
       setReportVisible(false);
       setReportTarget(null);
@@ -676,7 +677,7 @@ export default function Page() {
       </SafeAreaView>
     );
   } catch (err) {
-    console.error('Error rendering feed page', err);
+    logger.error('Error rendering feed page', err);
     return null;
   }
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -64,6 +64,7 @@ import { db, storage } from '../../firebase';
 import type { Wish } from '../../types/Wish';
 import { useAuth } from '@/contexts/AuthContext';
 import { DAILY_PROMPTS } from '../../constants/prompts';
+import * as logger from '@/helpers/logger';
 
 const typeInfo: Record<string, { emoji: string; color: string }> = {
   wish: { emoji: '💭', color: '#1e1e1e' },
@@ -141,10 +142,10 @@ export default function Page() {
   const [error, setError] = useState<string | null>(null);
 
   if (!db || !storage) {
-    console.error('Firebase modules undefined in index page', { db, storage });
+    logger.error('Firebase modules undefined in index page', { db, storage });
   }
   if (user === undefined) {
-    console.error('AuthContext returned undefined user');
+    logger.error('AuthContext returned undefined user');
   }
 
   const HIT_SLOP = { top: 10, bottom: 10, left: 10, right: 10 };
@@ -188,7 +189,7 @@ export default function Page() {
         setWishList([...boosted, ...normal]);
         setError(null);
       } catch (err) {
-        console.warn('Failed to load wishes', err);
+        logger.warn('Failed to load wishes', err);
         setError("Couldn't load data. Check your connection and try again.");
       } finally {
         setLoading(false);
@@ -221,7 +222,7 @@ export default function Page() {
         });
         setImpact({ wishes, boosts, gifts, giftTotal });
       } catch (err) {
-        console.error('Failed to load impact', err);
+        logger.error('Failed to load impact', err);
       }
     };
     loadImpact();
@@ -264,7 +265,7 @@ export default function Page() {
                   }));
                 }
               } catch (err) {
-                console.warn('Failed to fetch user', err);
+                logger.warn('Failed to fetch user', err);
                 if (publicStatus[id] === undefined) {
                   setPublicStatus((prev) => ({ ...prev, [id]: false }));
                 }
@@ -276,7 +277,7 @@ export default function Page() {
           }),
         );
       } catch (err) {
-        console.error('Failed to fetch public status', err);
+        logger.error('Failed to fetch public status', err);
       }
     };
     fetchStatus();
@@ -304,14 +305,14 @@ export default function Page() {
                 );
                 setFollowStatus((prev) => ({ ...prev, [id]: snap.exists() }));
               } catch (err) {
-                console.warn('Failed to fetch follow status for', id, err);
+                logger.warn('Failed to fetch follow status for', id, err);
                 setFollowStatus((prev) => ({ ...prev, [id]: false }));
               }
             }
           }),
         );
       } catch (err) {
-        console.error('Failed to fetch follow status', err);
+        logger.error('Failed to fetch follow status', err);
       }
     };
     fetchFollow();
@@ -329,7 +330,7 @@ export default function Page() {
           await AsyncStorage.setItem('seenWelcome', 'true');
         }
       } catch (err) {
-        console.error('Failed in showWelcome', err);
+        logger.error('Failed in showWelcome', err);
       }
     };
     showWelcome();
@@ -366,7 +367,7 @@ export default function Page() {
         const streak = await AsyncStorage.getItem('streakCount');
         if (streak) setStreakCount(parseInt(streak, 10));
       } catch (err) {
-        console.error('Failed to load prompt or streak', err);
+        logger.error('Failed to load prompt or streak', err);
       }
     };
 
@@ -399,7 +400,7 @@ export default function Page() {
       setRecording(rec);
       setIsRecording(true);
     } catch (err) {
-      console.error('❌ Failed to start recording:', err);
+      logger.error('❌ Failed to start recording:', err);
     }
   };
 
@@ -409,7 +410,7 @@ export default function Page() {
       const { uri } = await recording.stop();
       setRecordedUri(uri);
     } catch (err) {
-      console.error('❌ Failed to stop recording:', err);
+      logger.error('❌ Failed to stop recording:', err);
     } finally {
       setIsRecording(false);
       setRecording(null);
@@ -506,7 +507,7 @@ export default function Page() {
         }
       }
     } catch (err) {
-      console.error('AI rephrase failed', err);
+      logger.error('AI rephrase failed', err);
       Alert.alert('Failed to rephrase wish', 'Please try again later.');
     } finally {
       setRephrasing(false);
@@ -582,7 +583,7 @@ export default function Page() {
           JSON.stringify(history),
         );
       } catch (err) {
-        console.error('Failed to save reflection history', err);
+        logger.error('Failed to save reflection history', err);
       }
 
       setWish('');
@@ -600,7 +601,7 @@ export default function Page() {
       setPostConfirm(true);
       await updateStreak();
     } catch (error) {
-      console.error('❌ Failed to post wish:', error);
+      logger.error('❌ Failed to post wish:', error);
     } finally {
       setPosting(false);
     }
@@ -616,7 +617,7 @@ export default function Page() {
         timestamp: serverTimestamp(),
       });
     } catch (err) {
-      console.error('❌ Failed to submit report:', err);
+      logger.error('❌ Failed to submit report:', err);
     } finally {
       setReportVisible(false);
       setReportTarget(null);
@@ -660,7 +661,7 @@ export default function Page() {
       setWishList([...boosted, ...normal]);
       setError(null);
     } catch (err) {
-      console.error('❌ Failed to refresh wishes:', err);
+      logger.error('❌ Failed to refresh wishes:', err);
       setError("Couldn't load data. Check your connection and try again.");
     } finally {
       setRefreshing(false);
@@ -688,7 +689,7 @@ export default function Page() {
       })) as Wish[];
       setWishList((prev) => [...prev, ...more]);
     } catch (err) {
-      console.warn('Failed to load more wishes', err);
+      logger.warn('Failed to load more wishes', err);
       setError("Couldn't load data. Check your connection and try again.");
     }
   }, [lastDoc, user]);
@@ -725,7 +726,7 @@ export default function Page() {
           setGiftCount(snaps[0].size + snaps[1].size);
           setHasGiftMsg(msg);
         } catch (err) {
-          console.warn('Failed to fetch gifts', err);
+          logger.warn('Failed to fetch gifts', err);
         }
       };
       load();
@@ -803,7 +804,7 @@ export default function Page() {
               );
               if (res.url) await WebBrowser.openBrowserAsync(res.url);
             } catch (err) {
-              console.error('Failed to checkout', err);
+              logger.error('Failed to checkout', err);
             }
           },
         },
@@ -1427,7 +1428,7 @@ export default function Page() {
       </SafeAreaView>
     );
   } catch (err) {
-    console.error('Error rendering index page', err);
+    logger.error('Error rendering index page', err);
     return null;
   }
 }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -34,6 +34,7 @@ import {
 import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
 import { useSavedWishes } from '@/contexts/SavedWishesContext';
+import * as logger from '@/helpers/logger';
 
 export default function Page() {
   const { user, profile, signOut } = useAuth();
@@ -136,7 +137,7 @@ export default function Page() {
       setPostedList((prev) => [...prev, ...more]);
       setError(null);
     } catch (err) {
-      console.warn('Failed to load more posts', err);
+      logger.warn('Failed to load more posts', err);
       setError("Couldn't load data. Check your connection and try again.");
     }
   };
@@ -197,12 +198,12 @@ export default function Page() {
             );
             comments += cSnap.size;
           } catch (err) {
-            console.error('Failed to count comments', err);
+            logger.error('Failed to count comments', err);
           }
         }
         setBoostImpact({ likes, comments });
       } catch (err) {
-        console.warn('Failed to load profile wishes', err);
+        logger.warn('Failed to load profile wishes', err);
         setError("Couldn't load data. Check your connection and try again.");
       }
     };

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -47,6 +47,7 @@ import { db, storage } from '../../firebase';
 import { getAllWishes, getWishesByNickname } from '../../helpers/wishes';
 import { getWishComments } from '../../helpers/comments';
 import type { Profile } from '../../types/Profile';
+import * as logger from '@/helpers/logger';
 
 export default function Page() {
   const { theme, setTheme } = useTheme();
@@ -183,7 +184,7 @@ export default function Page() {
           });
         }
       } catch (err) {
-        console.warn('Failed to load analytics', err);
+        logger.warn('Failed to load analytics', err);
       }
     };
     fetchStats();
@@ -226,7 +227,7 @@ export default function Page() {
     for (const w of wishes) {
       try {
         const list = await getWishComments(w.id, (err) => {
-          console.error('Failed to fetch comments for export', err);
+          logger.error('Failed to fetch comments for export', err);
         });
         list.forEach((c) => {
           if (c.nickname === localUser?.nickname) comments.push(c);
@@ -266,7 +267,7 @@ export default function Page() {
     for (const wish of all) {
       try {
         const list = await getWishComments(wish.id, (err) => {
-          console.error('Failed to fetch comments for deletion', err);
+          logger.error('Failed to fetch comments for deletion', err);
         });
         for (const c of list) {
           if (c.nickname === localUser?.nickname) {
@@ -340,7 +341,7 @@ export default function Page() {
           await updateProfile({ stripeAccountId: data.accountId });
         if (data.url) await WebBrowser.openBrowserAsync(data.url);
       } catch (err) {
-        console.error('Failed to start Stripe onboarding', err);
+        logger.error('Failed to start Stripe onboarding', err);
       }
     }
   };

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { AppContainer } from '@/components/AppContainer';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { SavedWishesProvider } from '@/contexts/SavedWishesContext';
+import * as logger from '@/helpers/logger';
 import { Stack, useRouter, usePathname } from 'expo-router';
 import React, { useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -12,7 +13,7 @@ function LayoutInner() {
   const pathname = usePathname();
 
   if (loading === undefined) {
-    console.error('AuthContext loading value undefined');
+    logger.error('AuthContext loading value undefined');
   }
 
   useEffect(() => {

--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -19,6 +19,7 @@ import ConfettiCannon from 'react-native-confetti-cannon';
 import * as Linking from 'expo-linking';
 import { getWish, boostWish } from '../../helpers/wishes';
 import { formatTimeLeft } from '../../helpers/time';
+import * as logger from '@/helpers/logger';
 
 export default function BoostPage() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -48,7 +49,7 @@ export default function BoostPage() {
       setShowConfirm(true);
       setTimeout(() => setShowConfirm(false), 3000);
     } catch (err) {
-      console.error('Failed to apply free boost', err);
+      logger.error('Failed to apply free boost', err);
     }
   };
 
@@ -102,7 +103,7 @@ export default function BoostPage() {
         setTimeout(() => setShowConfirm(false), 3000);
       }
     } catch (err) {
-      console.error('Failed to create checkout session', err);
+      logger.error('Failed to create checkout session', err);
     } finally {
       setLoading(false);
     }

--- a/app/journal.tsx
+++ b/app/journal.tsx
@@ -25,6 +25,7 @@ import { addWish } from '../helpers/wishes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { db } from '../firebase';
+import * as logger from '@/helpers/logger';
 
 const prompts = [
   '💭 What\u2019s your biggest wish this week?',
@@ -105,7 +106,7 @@ export default function JournalPage() {
             }
             await AsyncStorage.removeItem('offlineJournalEntries');
           } catch (err) {
-            console.warn('Failed to sync offline journal entries', err);
+            logger.warn('Failed to sync offline journal entries', err);
           }
         }
         setEntries(loaded);
@@ -152,7 +153,7 @@ export default function JournalPage() {
         timestamp: serverTimestamp(),
       });
     } catch (err) {
-      console.warn('Failed to save entry online', err);
+      logger.warn('Failed to save entry online', err);
       const offlineRaw = await AsyncStorage.getItem('offlineJournalEntries');
       const offline = offlineRaw ? JSON.parse(offlineRaw) : [];
       offline.push({ ...data, timestamp: Date.now() });
@@ -192,7 +193,7 @@ export default function JournalPage() {
       });
       Alert.alert('Wish posted!');
     } catch (err) {
-      console.error('Failed to share as wish', err);
+      logger.error('Failed to share as wish', err);
     }
   };
 

--- a/app/profile/[displayName].tsx
+++ b/app/profile/[displayName].tsx
@@ -30,6 +30,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Colors } from '@/constants/Colors';
 import type { Wish } from '../../types/Wish';
+import * as logger from '@/helpers/logger';
 
 const typeInfo: Record<string, { emoji: string; color: string }> = {
   wish: { emoji: '💭', color: '#1e1e1e' },
@@ -77,7 +78,7 @@ export default function Page() {
           );
           setIsFollowing(followSnap.exists());
         } catch (err) {
-          console.warn('Failed to fetch follow status', err);
+          logger.warn('Failed to fetch follow status', err);
         }
       }
       const wishSnap = await getDocs(

--- a/app/profile/[username].tsx
+++ b/app/profile/[username].tsx
@@ -25,6 +25,7 @@ import { db } from '../../firebase';
 import { followUser, unfollowUser } from '../../helpers/followers';
 import { useAuth } from '@/contexts/AuthContext';
 import type { Wish } from '../../types/Wish';
+import * as logger from '@/helpers/logger';
 
 export default function Page() {
   const { username } = useLocalSearchParams<{ username: string }>();
@@ -67,7 +68,7 @@ export default function Page() {
             );
             setIsFollowing(followSnap.exists());
           } catch (err) {
-            console.warn('Failed to fetch follow status', err);
+            logger.warn('Failed to fetch follow status', err);
           }
         }
         const q = query(
@@ -85,7 +86,7 @@ export default function Page() {
         })) as Wish[];
         setWishes(list);
       } catch (err) {
-        console.warn('Failed to load profile', err);
+        logger.warn('Failed to load profile', err);
         setPrivateProfile(true);
       } finally {
         setLoading(false);

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -63,6 +63,7 @@ import { db } from '../../firebase';
 import type { Wish } from '../../types/Wish';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackEvent } from '@/helpers/analytics';
+import * as logger from '@/helpers/logger';
 
 const baseTypeInfo = {
   wish: { emoji: '💭', color: '#333333' },
@@ -203,13 +204,13 @@ export default function Page() {
             const snap = await getDoc(doc(db, 'users', data.userId));
             setOwner(snap.exists() ? snap.data() : null);
           } catch (err) {
-            console.warn('Failed to fetch wish owner', err);
+            logger.warn('Failed to fetch wish owner', err);
             setOwner(null);
           }
         }
       }
     } catch (err) {
-      console.error('❌ Failed to load wish:', err);
+      logger.error('❌ Failed to load wish:', err);
       setError('Failed to load wish');
     } finally {
       setLoading(false);
@@ -225,7 +226,7 @@ export default function Page() {
         );
         if (snap.exists()) setHasVoted(true);
       } catch (err) {
-        console.warn('Failed to check vote', err);
+        logger.warn('Failed to check vote', err);
       }
     };
     checkVote();
@@ -262,7 +263,7 @@ export default function Page() {
         setLoading(false);
       },
       (err) => {
-        console.error('❌ Failed to load comments:', err);
+        logger.error('❌ Failed to load comments:', err);
         setError('Failed to load comments');
         setLoading(false);
       },
@@ -293,7 +294,7 @@ export default function Page() {
                   : false,
               }));
             } catch (err) {
-              console.warn('Failed to fetch user status', err);
+              logger.warn('Failed to fetch user status', err);
               setPublicStatus((prev) => ({ ...prev, [uid]: false }));
             }
           }
@@ -347,7 +348,7 @@ export default function Page() {
       setPlayer(p);
       setIsPlaying(true);
     } catch (err) {
-      console.error('❌ Failed to play audio:', err);
+      logger.error('❌ Failed to play audio:', err);
     }
   }, [player, isPlaying, wish]);
 
@@ -378,7 +379,7 @@ export default function Page() {
           userReactions: {},
         },
         (err) => {
-          console.error('❌ Failed to post comment:', err);
+          logger.error('❌ Failed to post comment:', err);
         },
       );
       setComment('');
@@ -409,7 +410,7 @@ export default function Page() {
           prevEmoji,
           currentUser,
           (err) => {
-            console.error('❌ Failed to update reaction:', err);
+            logger.error('❌ Failed to update reaction:', err);
           },
         );
       } catch {
@@ -441,7 +442,7 @@ export default function Page() {
           });
         }
       } catch (err) {
-        console.error('❌ Failed to submit report:', err);
+        logger.error('❌ Failed to submit report:', err);
       } finally {
         setReportVisible(false);
         setReportTarget(null);
@@ -468,7 +469,7 @@ export default function Page() {
         setHasVoted(true);
         await fetchWish();
       } catch (err) {
-        console.error('❌ Failed to vote:', err);
+        logger.error('❌ Failed to vote:', err);
       }
     },
     [fetchWish, hasVoted, wish, user],
@@ -481,7 +482,7 @@ export default function Page() {
         await setFulfillmentLink(id as string, link.trim());
         await fetchWish();
       } catch (err) {
-        console.error('❌ Failed to fulfill wish:', err);
+        logger.error('❌ Failed to fulfill wish:', err);
       }
     },
     [fetchWish, id],
@@ -1092,7 +1093,7 @@ export default function Page() {
                               await WebBrowser.openBrowserAsync(res.url);
                             setShowThanks(true);
                           } catch (err) {
-                            console.error('Failed to checkout', err);
+                            logger.error('Failed to checkout', err);
                           }
                         }
                         setConfirmGift(null);
@@ -1165,7 +1166,7 @@ export default function Page() {
                             },
                           );
                         } catch (err) {
-                          console.error('Failed to save message', err);
+                          logger.error('Failed to save message', err);
                         }
                         setThanksMessage('');
                         setShowThanks(false);

--- a/components/WishCard.tsx
+++ b/components/WishCard.tsx
@@ -17,6 +17,7 @@ import { collection, getDocs, doc, onSnapshot } from 'firebase/firestore';
 import { formatTimeLeft } from '../helpers/time';
 import { useAuth } from '@/contexts/AuthContext';
 import ReactionBar, { ReactionKey } from './ReactionBar';
+import * as logger from '@/helpers/logger';
 
 const typeColors: Record<string, string> = {
   dream: '#312e81',
@@ -67,7 +68,7 @@ export const WishCard: React.FC<{
         setGiftCount(snaps[0].size + snaps[1].size);
         setHasGiftMsg(msg);
       } catch (err) {
-        console.warn('Failed to fetch gifts', err);
+        logger.warn('Failed to fetch gifts', err);
       }
     };
     load();
@@ -125,7 +126,7 @@ export const WishCard: React.FC<{
       try {
         await updateWishReaction(wish.id, key, user.uid);
       } catch (err) {
-        console.warn('Failed to react', err);
+        logger.warn('Failed to react', err);
       }
     },
     [wish.id, user?.uid],

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -32,11 +32,12 @@ import {
   resetPassword as resetPasswordService,
   signOut as signOutService,
 } from '../services/auth';
+import * as logger from '@/helpers/logger';
 
 WebBrowser.maybeCompleteAuthSession();
 
 if (!auth || !db) {
-  console.error('Firebase modules are undefined in AuthContext');
+  logger.error('Firebase modules are undefined in AuthContext');
 }
 
 interface AuthContextValue {
@@ -95,7 +96,7 @@ export const AuthProvider = ({
         try {
           await signInAnonymouslyService();
         } catch (err) {
-          console.error('Anonymous sign-in failed', err);
+          logger.error('Anonymous sign-in failed', err);
           setLoading(false);
         }
         return;

--- a/firebase.ts
+++ b/firebase.ts
@@ -10,6 +10,7 @@ import {
 import { getAnalytics, isSupported, Analytics } from 'firebase/analytics';
 import { Platform } from 'react-native';
 import { trackEvent } from '@/helpers/analytics';
+import * as logger from '@/helpers/logger';
 
 const requiredEnvVars = [
   'EXPO_PUBLIC_FIREBASE_API_KEY',
@@ -57,7 +58,7 @@ isSupported()
     }
   })
   .catch((error) => {
-    console.warn('Failed to initialize analytics:', error);
+    logger.warn('Failed to initialize analytics:', error);
     const env = requiredEnvVars.reduce<Record<string, string | undefined>>(
       (acc, key) => {
         acc[key] = process.env[key];

--- a/functions/src/createCheckoutSession.ts
+++ b/functions/src/createCheckoutSession.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
+import * as logger from '../../helpers/logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',
@@ -48,7 +49,7 @@ export const createCheckoutSession = functions.https.onRequest(
 
       res.json({ url: session.url, sessionId: session.id });
     } catch (err) {
-      console.error('Error creating checkout session', err);
+      logger.error('Error creating checkout session', err);
       res.status(500).send('Internal error');
     }
   },

--- a/functions/src/createGiftCheckoutSession.ts
+++ b/functions/src/createGiftCheckoutSession.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
+import * as logger from '../../helpers/logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',
@@ -60,7 +61,7 @@ export const createGiftCheckoutSession = functions.https.onRequest(
 
       res.json({ url: session.url });
     } catch (err) {
-      console.error('Error creating gift checkout session', err);
+      logger.error('Error creating gift checkout session', err);
       res.status(500).send('Internal error');
     }
   },

--- a/functions/src/createStripeAccountLink.ts
+++ b/functions/src/createStripeAccountLink.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
+import * as logger from '../../helpers/logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',
@@ -38,7 +39,7 @@ export const createStripeAccountLink = functions.https.onRequest(
       });
       res.json({ url: link.url, accountId });
     } catch (err) {
-      console.error('Error creating account link', err);
+      logger.error('Error creating account link', err);
       res.status(500).send('Internal error');
     }
   },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { Expo } from 'expo-server-sdk';
+import * as logger from '../../helpers/logger';
 
 admin.initializeApp();
 const db = admin.firestore();
@@ -30,7 +31,7 @@ async function sendPush(
         lastSent: admin.firestore.FieldValue.serverTimestamp(),
       });
     } catch (err) {
-      console.error('Error sending Expo push notification', err);
+      logger.error('Error sending Expo push notification', err);
       if (fcmToken) {
         try {
           await admin
@@ -40,7 +41,7 @@ async function sendPush(
             lastSent: admin.firestore.FieldValue.serverTimestamp(),
           });
         } catch (err2) {
-          console.error('Error sending fallback FCM notification', err2);
+          logger.error('Error sending fallback FCM notification', err2);
         }
       }
     }
@@ -53,7 +54,7 @@ async function sendPush(
         lastSent: admin.firestore.FieldValue.serverTimestamp(),
       });
     } catch (err) {
-      console.error('Error sending FCM notification', err);
+      logger.error('Error sending FCM notification', err);
     }
   }
   return null;

--- a/functions/src/rephraseWish.ts
+++ b/functions/src/rephraseWish.ts
@@ -1,4 +1,5 @@
 import * as functions from 'firebase-functions';
+import * as logger from '../../helpers/logger';
 
 interface RephraseRequest {
   text: string;
@@ -16,7 +17,7 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const hasValidApiKey = typeof OPENAI_API_KEY === 'string' && OPENAI_API_KEY.startsWith('sk-');
 
 if (!hasValidApiKey) {
-  console.error('Invalid or missing OPENAI_API_KEY');
+  logger.error('Invalid or missing OPENAI_API_KEY');
 }
 
 export const rephraseWish = functions.https.onRequest(async (req, res) => {
@@ -54,14 +55,14 @@ export const rephraseWish = functions.https.onRequest(async (req, res) => {
     });
 
     if (response.status === 401) {
-      console.error('Invalid OpenAI API key');
+      logger.error('Invalid OpenAI API key');
       res.status(500).send('Invalid OpenAI API key');
       return;
     }
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('OpenAI API error', response.status, errorText);
+      logger.error('OpenAI API error', response.status, errorText);
       res.status(response.status).send('OpenAI API error');
       return;
     }
@@ -70,7 +71,7 @@ export const rephraseWish = functions.https.onRequest(async (req, res) => {
     const suggestion = data.choices?.[0]?.message?.content?.trim() || null;
     res.json({ suggestion });
   } catch (err) {
-    console.error('rephraseWish error', err);
+    logger.error('rephraseWish error', err);
     res.status(500).send('error');
   }
 });

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
+import * as logger from '../../helpers/logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',
@@ -18,7 +19,7 @@ export const stripeWebhook = functions.https.onRequest(async (req, res) => {
       process.env.STRIPE_WEBHOOK_SECRET as string,
     );
   } catch (err) {
-    console.error('Webhook verification failed', err);
+    logger.error('Webhook verification failed', err);
     res.status(400).send('Webhook Error');
     return;
   }

--- a/helpers/analytics.ts
+++ b/helpers/analytics.ts
@@ -1,14 +1,15 @@
 import { logEvent } from 'firebase/analytics';
 import { analytics } from '@/firebase';
+import * as logger from './logger';
 
 export function trackEvent(name: string, params?: Record<string, any>) {
   try {
     if (analytics) {
       logEvent(analytics, name, params);
     } else {
-      console.warn('Analytics not ready');
+      logger.warn('Analytics not ready');
     }
   } catch (err) {
-    console.warn('Failed to log analytics event:', err);
+    logger.warn('Failed to log analytics event:', err);
   }
 }

--- a/helpers/comments.ts
+++ b/helpers/comments.ts
@@ -12,6 +12,7 @@ import {
   Timestamp,
 } from 'firebase/firestore';
 import { db } from '../firebase';
+import * as logger from './logger';
 
 export type Comment<Extra extends Record<string, unknown> = {}> = {
   id: string;
@@ -47,17 +48,17 @@ export function listenWishComments<Extra extends Record<string, unknown> = {}>(
           }));
           cb(data as Comment<Extra>[]);
         } catch (err) {
-          console.error('Error processing wish comments snapshot', err);
+          logger.error('Error processing wish comments snapshot', err);
           onError?.(err);
         }
       },
       (err) => {
-        console.error('Error listening to wish comments', err);
+        logger.error('Error listening to wish comments', err);
         onError?.(err);
       },
     );
   } catch (err) {
-    console.error('Error setting up wish comments listener', err);
+    logger.error('Error setting up wish comments listener', err);
     onError?.(err);
     return () => {};
   }
@@ -74,7 +75,7 @@ export async function addComment<Extra extends Record<string, unknown> = {}>(
       ...data,
     });
   } catch (err) {
-    console.error('Error adding comment', err);
+    logger.error('Error adding comment', err);
     onError?.(err);
     throw err;
   }
@@ -113,7 +114,7 @@ export async function updateCommentReaction<Extra extends Record<string, unknown
 
     return await updateDoc(ref, { reactions, userReactions });
   } catch (err) {
-    console.error('Error updating comment reaction', err);
+    logger.error('Error updating comment reaction', err);
     onError?.(err);
     throw err;
   }
@@ -139,7 +140,7 @@ export async function getWishComments<Extra extends Record<string, unknown> = {}
       return comment;
     });
   } catch (err) {
-    console.error('Error fetching wish comments', err);
+    logger.error('Error fetching wish comments', err);
     onError?.(err);
     throw err;
   }

--- a/helpers/followers.ts
+++ b/helpers/followers.ts
@@ -13,6 +13,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import type { Wish } from '../types/Wish';
+import * as logger from './logger';
 
 /**
  * Firestore `in` queries only accept up to 10 values. This helper splits an
@@ -35,7 +36,7 @@ export async function followUser(currentUser: string, targetUser: string) {
       setDoc(followingRef, { createdAt: serverTimestamp() }),
     ]);
   } catch (error) {
-    console.error('Error following user', error);
+    logger.error('Error following user', error);
     throw error;
   }
 }
@@ -46,7 +47,7 @@ export async function unfollowUser(currentUser: string, targetUser: string) {
   try {
     await Promise.all([deleteDoc(followerRef), deleteDoc(followingRef)]);
   } catch (error) {
-    console.error('Error unfollowing user', error);
+    logger.error('Error unfollowing user', error);
     throw error;
   }
 }
@@ -92,19 +93,19 @@ export function listenFollowingWishes(
                 .sort((a, b) => (b as any).timestamp - (a as any).timestamp);
               cb(merged as Wish[]);
             } catch (err) {
-              console.error('Error processing following wishes snapshot', err);
+              logger.error('Error processing following wishes snapshot', err);
               onError?.(err);
             }
           },
           (err) => {
-            console.error('Error listening to following wishes', err);
+            logger.error('Error listening to following wishes', err);
             onError?.(err);
           },
         );
         unsubs.push(unsub);
       });
     } catch (err) {
-      console.error('Error fetching following ids', err);
+      logger.error('Error fetching following ids', err);
       onError?.(err);
     }
   })();
@@ -141,7 +142,7 @@ export async function getFollowingWishes(userId: string): Promise<Wish[]> {
       .sort((a, b) => (b as any).timestamp - (a as any).timestamp)
       .slice(0, 20);
   } catch (error) {
-    console.error('Error getting following wishes', error);
+    logger.error('Error getting following wishes', error);
     throw error;
   }
 }

--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -1,0 +1,21 @@
+let telemetry = null;
+function emit(level, args) {
+  if (telemetry) {
+    try {
+      telemetry(level, ...args);
+    } catch {
+      // ignore telemetry errors
+    }
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    console[level](...args);
+  }
+}
+module.exports = {
+  setTelemetry: (fn) => {
+    telemetry = fn;
+  },
+  log: (...args) => emit('log', args),
+  warn: (...args) => emit('warn', args),
+  error: (...args) => emit('error', args),
+};

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -1,0 +1,24 @@
+export type TelemetryFn = (level: 'log' | 'warn' | 'error', ...args: any[]) => void;
+
+let telemetry: TelemetryFn | null = null;
+
+export function setTelemetry(fn: TelemetryFn) {
+  telemetry = fn;
+}
+
+function emit(level: 'log' | 'warn' | 'error', args: any[]) {
+  if (telemetry) {
+    try {
+      telemetry(level, ...args);
+    } catch {
+      // ignore telemetry errors
+    }
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    console[level](...args);
+  }
+}
+
+export const log = (...args: any[]) => emit('log', args);
+export const warn = (...args: any[]) => emit('warn', args);
+export const error = (...args: any[]) => emit('error', args);

--- a/hooks/useDailyQuote.ts
+++ b/hooks/useDailyQuote.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DAILY_QUOTE_ENABLED } from '@/constants/featureFlags';
+import * as logger from '@/helpers/logger';
 
 const QUOTES = [
   'Believe in yourself!',
@@ -19,7 +20,7 @@ export default function useDailyQuote() {
           Alert.alert('Motivation', q);
         }
       } catch (err) {
-        console.warn('Failed to load daily quote', err);
+        logger.warn('Failed to load daily quote', err);
       }
     };
 

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -10,6 +10,7 @@ import {
 } from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthContext';
 import { db } from '../firebase';
+import * as logger from '@/helpers/logger';
 
 export interface NotificationDoc {
   type: string;
@@ -48,12 +49,12 @@ export default function useNotifications() {
             })),
           );
         } catch (err) {
-          console.error('Error processing notifications snapshot', err);
+          logger.error('Error processing notifications snapshot', err);
           setError(err as Error);
         }
       },
       (err) => {
-        console.error('Error listening to notifications', err);
+        logger.error('Error listening to notifications', err);
         setError(err);
       },
     );
@@ -73,7 +74,7 @@ export default function useNotifications() {
           ),
       );
     } catch (err) {
-      console.error('Error marking notifications read', err);
+      logger.error('Error marking notifications read', err);
       throw err;
     }
   };

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -5,6 +5,7 @@ import { Platform } from 'react-native';
 import { doc, updateDoc } from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthContext';
 import { db } from '../firebase';
+import * as logger from '@/helpers/logger';
 
 export default function usePushNotifications() {
   const { user } = useAuth();
@@ -38,7 +39,7 @@ export default function usePushNotifications() {
       try {
         await updateDoc(doc(db, 'users', user.uid), { fcmToken: data });
       } catch (err) {
-        console.error('Failed to save push token', err);
+        logger.error('Failed to save push token', err);
       }
 
       if (Platform.OS === 'android') {

--- a/hooks/useReferral.ts
+++ b/hooks/useReferral.ts
@@ -12,6 +12,7 @@ import {
   serverTimestamp,
 } from 'firebase/firestore';
 import { db } from '../firebase';
+import * as logger from '@/helpers/logger';
 
 export const useReferral = () => {
   const checkInvite = async () => {
@@ -25,7 +26,7 @@ export const useReferral = () => {
         }
       }
     } catch (err) {
-      console.error('Failed to parse initial URL', err);
+      logger.error('Failed to parse initial URL', err);
     }
   };
 
@@ -55,7 +56,7 @@ export const useReferral = () => {
         await AsyncStorage.removeItem('inviteRef');
       }
     } catch (err) {
-      console.error('Failed to process referral', err);
+      logger.error('Failed to process referral', err);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   "jest": {
     "preset": "jest-expo",
     "setupFilesAfterEnv": [
-      "@testing-library/jest-native/extend-expect"
+      "@testing-library/jest-native/extend-expect",
+      "<rootDir>/tests/setupLogger.ts"
     ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/$1"

--- a/scripts/fix-eas-project.js
+++ b/scripts/fix-eas-project.js
@@ -6,6 +6,7 @@
  */
 const fs = require('fs');
 const { execSync } = require('child_process');
+const logger = require('../helpers/logger');
 
 const APP_JSON = 'app.json';
 
@@ -25,7 +26,7 @@ function cleanProjectId() {
       delete appJson.expo.extra.eas;
     }
     fs.writeFileSync(APP_JSON, JSON.stringify(appJson, null, 2));
-    console.log('Removed invalid eas.projectId from app.json');
+    logger.log('Removed invalid eas.projectId from app.json');
   }
 }
 
@@ -33,7 +34,7 @@ function runEasInit() {
   try {
     execSync('eas init', { stdio: 'inherit' });
   } catch (err) {
-    console.error('`eas init` failed:', err.message);
+    logger.error('`eas init` failed:', err.message);
   }
 }
 

--- a/tests/setupLogger.ts
+++ b/tests/setupLogger.ts
@@ -1,0 +1,5 @@
+jest.mock('@/helpers/logger', () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));


### PR DESCRIPTION
## Summary
- add helpers/logger for telemetry-ready log, warn, and error helpers
- replace direct console usage across app, functions, and scripts
- mock logger in tests to keep output clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68961bf0db5883279c37c4f6981ccafe