### PR TITLE
feat: enable wish editing

### DIFF
--- a/helpers/wishes.ts
+++ b/helpers/wishes.ts
@@ -181,6 +181,11 @@ export async function likeWish(id: string) {
   return updateDoc(ref, { likes: increment(1) });
 }
 
+export async function updateWish(id: string, data: Partial<Wish>) {
+  const ref = doc(db, 'wishes', id);
+  return updateDoc(ref, data);
+}
+
 export async function updateWishReaction(
   id: string,
   emoji: ReactionType,


### PR DESCRIPTION
## Summary
- add `updateWish` helper for partial wish updates
- allow wish owners to edit or delete their wish

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966c795b448327b2c2049cf123dcad