### PR TITLE
Enable editing and deleting wish comments

### DIFF
--- a/helpers/comments.ts
+++ b/helpers/comments.ts
@@ -9,6 +9,7 @@ import {
   getDoc,
   updateDoc,
   getDocs,
+  deleteDoc,
   Timestamp,
 } from 'firebase/firestore';
 import { db } from '../firebase';
@@ -82,6 +83,39 @@ export async function addComment<
     });
   } catch (err) {
     logger.error('Error adding comment', err);
+    onError?.(err);
+    throw err;
+  }
+}
+
+export async function updateComment<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+>(
+  wishId: string,
+  commentId: string,
+  data: Partial<Omit<Comment<Extra>, 'id'>>,
+  onError?: (err: unknown) => void,
+) {
+  try {
+    const ref = doc(db, 'wishes', wishId, 'comments', commentId);
+    return await updateDoc(ref, data);
+  } catch (err) {
+    logger.error('Error updating comment', err);
+    onError?.(err);
+    throw err;
+  }
+}
+
+export async function deleteComment(
+  wishId: string,
+  commentId: string,
+  onError?: (err: unknown) => void,
+) {
+  try {
+    const ref = doc(db, 'wishes', wishId, 'comments', commentId);
+    return await deleteDoc(ref);
+  } catch (err) {
+    logger.error('Error deleting comment', err);
     onError?.(err);
     throw err;
   }


### PR DESCRIPTION
## Summary
- add helpers to update and delete comments
- allow users to edit or remove their own comments in wish view

## Testing
- `npm test` *(fails: Incorrect version of "react-test-renderer" detected)*

------
https://chatgpt.com/codex/tasks/task_e_68966e854c0c832785eb5b55e217f79d