### PR TITLE
Add share buttons for wishes

### DIFF
--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -56,9 +56,11 @@ import {
   RefreshControl,
   ScrollView,
   Modal,
-  Linking,
+  Linking as RNLinking,
+  Share,
 } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
+import * as Linking from 'expo-linking';
 import { useTheme } from '@/contexts/ThemeContext';
 import { BarChart } from 'react-native-chart-kit';
 import ReportDialog from '../../components/ReportDialog';
@@ -539,6 +541,16 @@ export default function Page() {
     setConfirmGift({ link });
   }, []);
 
+  const handleShare = useCallback(async () => {
+    if (!wish?.id) return;
+    const wishUrl = Linking.createURL(`/wish/${wish.id}`);
+    try {
+      await Share.share({ message: wishUrl });
+    } catch (err) {
+      logger.warn('Failed to share wish', err);
+    }
+  }, [wish?.id]);
+
   const handleSendMoney = useCallback(
     (amount: number) => {
       if (!wish || !wish.userId) return;
@@ -833,9 +845,24 @@ export default function Page() {
                     },
                   ]}
                 >
-                  <Text style={[styles.wishCategory, { color: theme.tint }]}>
-                    {typeInfo[t].emoji} #{wish.category}
-                  </Text>
+                  <View
+                    style={{
+                      flexDirection: 'row',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Text style={[styles.wishCategory, { color: theme.tint }]}>
+                      {typeInfo[t].emoji} #{wish.category}
+                    </Text>
+                    <TouchableOpacity onPress={handleShare} hitSlop={HIT_SLOP}>
+                      <Ionicons
+                        name="share-outline"
+                        size={20}
+                        color={theme.tint}
+                      />
+                    </TouchableOpacity>
+                  </View>
                   <Text style={[styles.wishText, { color: theme.text }]}>
                     {wish.text}
                   </Text>
@@ -1196,7 +1223,7 @@ export default function Page() {
             <TouchableOpacity
               onPress={() => {
                 trackEvent('open_fulfillment_link');
-                Linking.openURL(wish.fulfillmentLink!);
+                RNLinking.openURL(wish.fulfillmentLink!);
               }}
               style={{ marginTop: 8 }}
             >

--- a/components/WishCard.tsx
+++ b/components/WishCard.tsx
@@ -5,7 +5,10 @@ import {
   Text,
   TouchableOpacity,
   Animated,
+  Share,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Linking from 'expo-linking';
 import { useRouter } from 'expo-router';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useSavedWishes } from '@/contexts/SavedWishesContext';
@@ -131,6 +134,16 @@ export const WishCard: React.FC<{
     [wish.id, user?.uid],
   );
 
+  const handleShare = useCallback(async () => {
+    if (!wish.id) return;
+    const wishUrl = Linking.createURL(`/wish/${wish.id}`);
+    try {
+      await Share.share({ message: wishUrl });
+    } catch (err) {
+      logger.warn('Failed to share wish', err);
+    }
+  }, [wish.id]);
+
   return (
     <Animated.View
       style={[
@@ -178,13 +191,22 @@ export const WishCard: React.FC<{
           <Image source={{ uri: wish.imageUrl }} style={styles.preview} />
         )}
       </TouchableOpacity>
-      <ReactionBar
-        wish={wish}
-        userReaction={userReaction}
-        onReact={handleReact}
-        onToggleSave={() => wish.id && toggleSave(wish.id)}
-        isSaved={!!wish.id && !!saved[wish.id]}
-      />
+      <View style={styles.actionRow}>
+        <ReactionBar
+          wish={wish}
+          userReaction={userReaction}
+          onReact={handleReact}
+          onToggleSave={() => wish.id && toggleSave(wish.id)}
+          isSaved={!!wish.id && !!saved[wish.id]}
+        />
+        <TouchableOpacity
+          onPress={handleShare}
+          style={styles.shareButton}
+          testID="share-button"
+        >
+          <Ionicons name="share-outline" size={20} color={theme.tint} />
+        </TouchableOpacity>
+      </View>
       {isBoosted && (
         <Text style={[styles.boostLabel, { color: theme.tint }]}>
           ⏳ Boost expires in {timeLeft}
@@ -265,6 +287,16 @@ const styles = StyleSheet.create({
   },
   reportButton: {
     marginTop: 4,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  shareButton: {
+    marginTop: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    borderRadius: 6,
   },
 });
 


### PR DESCRIPTION
## Summary
- add share icon to wish cards for quick sharing of wish links
- expose share button on individual wish page near header

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module 'eslint/config')*
- `npm run typecheck` *(fails: File 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68967163f7d48327a07373aacd9e8d0e