### PR TITLE
Remove stray escape characters in free boost button

### DIFF
--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -190,11 +190,9 @@ export default function BoostPage() {
               onPress={handleFreeBoost}
               style={[styles.button, { marginBottom: 10 }]}
             >
-              \
               <Text style={styles.buttonText}>
                 Use Free Boost ({profile.boostCredits})
               </Text>
-              \
             </TouchableOpacity>
           )}
           <TouchableOpacity


### PR DESCRIPTION
## Summary
- remove stray backslash characters around free boost button text

## Testing
- `npm test` *(fails: Incorrect version of "react-test-renderer" detected. Expected "19.0.0", but found "19.1.1".)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689675c72db4832783a77dc9e6a69f35