### PR TITLE
feat: internalize logger for cloud functions

### DIFF
--- a/functions/src/createCheckoutSession.ts
+++ b/functions/src/createCheckoutSession.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
-import * as logger from '../../helpers/logger';
+import * as logger from './logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',

--- a/functions/src/createGiftCheckoutSession.ts
+++ b/functions/src/createGiftCheckoutSession.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
-import * as logger from '../../helpers/logger';
+import * as logger from './logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',

--- a/functions/src/createStripeAccountLink.ts
+++ b/functions/src/createStripeAccountLink.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
-import * as logger from '../../helpers/logger';
+import * as logger from './logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { Expo } from 'expo-server-sdk';
-import * as logger from '../../helpers/logger';
+import * as logger from './logger';
 
 admin.initializeApp();
 const db = admin.firestore();

--- a/functions/src/logger.ts
+++ b/functions/src/logger.ts
@@ -1,0 +1,24 @@
+export type TelemetryFn = (level: 'log' | 'warn' | 'error', ...args: any[]) => void;
+
+let telemetry: TelemetryFn | null = null;
+
+export function setTelemetry(fn: TelemetryFn) {
+  telemetry = fn;
+}
+
+function emit(level: 'log' | 'warn' | 'error', args: any[]) {
+  if (telemetry) {
+    try {
+      telemetry(level, ...args);
+    } catch {
+      // ignore telemetry errors
+    }
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    console[level](...args);
+  }
+}
+
+export const log = (...args: any[]) => emit('log', args);
+export const warn = (...args: any[]) => emit('warn', args);
+export const error = (...args: any[]) => emit('error', args);

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import Stripe from 'stripe';
-import * as logger from '../../helpers/logger';
+import * as logger from './logger';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',


### PR DESCRIPTION
## Summary
- add logger utility inside functions project
- update cloud functions to import the internal logger

## Testing
- `npm --prefix functions run build` (fails: Cannot find module 'firebase-functions' or its corresponding type declarations)
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_689676cce71c8327bbab318dedb40d6f