### PR TITLE
Pass Expo project ID when requesting push token

### DIFF
--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import { doc, updateDoc } from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthContext';
@@ -34,7 +35,8 @@ export default function usePushNotifications() {
       }
       if (status !== 'granted') return;
 
-      const { data } = await Notifications.getExpoPushTokenAsync();
+      const projectId = Constants?.expoConfig?.extra?.eas?.projectId;
+      const { data } = await Notifications.getExpoPushTokenAsync({ projectId });
       setToken(data);
       try {
         await updateDoc(doc(db, 'users', user.uid), { fcmToken: data });


### PR DESCRIPTION
## Summary
- ensure `usePushNotifications` uses Expo project ID when requesting push token

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689677e801dc8327a2c186309038c36f