### PR TITLE
fix: enable metro package exports

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -17,4 +17,8 @@ config.resolver.alias = {
   '@': path.resolve(__dirname),
 };
 
+// Enable support for packages that use the `exports` field in their package.json.
+// This allows Metro to resolve modern ESM-only packages such as `i18next`.
+config.resolver.unstable_enablePackageExports = true;
+
 module.exports = config;


### PR DESCRIPTION
## Summary
- allow metro to resolve packages that use the exports field such as i18next

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module 'eslint/config')*
- `npm run typecheck` *(fails: File 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896799bccec83278eebdef00877570b