### PR TITLE
Gracefully handle missing Firebase env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    # then edit .env and fill in the values
    ```
 
+   The app requires the following Firebase environment variables:
+
+   - `EXPO_PUBLIC_FIREBASE_API_KEY`
+   - `EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN`
+   - `EXPO_PUBLIC_FIREBASE_PROJECT_ID`
+   - `EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET`
+   - `EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`
+   - `EXPO_PUBLIC_FIREBASE_APP_ID`
+   - `EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID`
+
+   Missing values will disable Firebase features at runtime.
+
 3. Start the app
 
    ```bash

--- a/firebase.ts
+++ b/firebase.ts
@@ -21,47 +21,66 @@ const requiredEnvVars = [
   'EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID',
 ];
 
-requiredEnvVars.forEach((name) => {
-  if (!process.env[name]) {
-    throw new Error(`Missing environment variable: ${name}`);
-  }
-});
+const missingEnvVars = requiredEnvVars.filter((name) => !process.env[name]);
 
-const firebaseConfig = {
-  apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
-  measurementId: process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID,
-};
+if (missingEnvVars.length > 0) {
+  missingEnvVars.forEach((name) =>
+    logger.error(`Missing environment variable: ${name}`)
+  );
+  logger.error(
+    'Firebase configuration incomplete. Firebase features will be disabled.'
+  );
+}
 
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+export const firebaseEnabled = missingEnvVars.length === 0;
 
-export const auth =
-  Platform.OS === 'web'
+const firebaseConfig = firebaseEnabled
+  ? {
+      apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+      authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+      projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+      storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+      messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+      appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+      measurementId: process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID,
+    }
+  : undefined;
+
+const app =
+  firebaseConfig && getApps().length
+    ? getApp()
+    : firebaseConfig
+    ? initializeApp(firebaseConfig)
+    : undefined;
+
+export const auth = app
+  ? Platform.OS === 'web'
     ? getAuth(app)
     : initializeAuth(app, {
         persistence: getReactNativePersistence(AsyncStorage),
-      });
-export const db = getFirestore(app);
-export const storage = getStorage(app);
+      })
+  : undefined;
+export const db = app ? getFirestore(app) : undefined;
+export const storage = app ? getStorage(app) : undefined;
 
 let analytics: Analytics | undefined;
 
-if (process.env.EXPO_PUBLIC_ENV === 'production') {
-  isSupported()
-    .then((supported) => {
-      if (supported) {
-        analytics = getAnalytics(app);
-      }
-    })
-    .catch((error) => {
-      logger.warn('Failed to initialize analytics:', error);
-    });
+if (app) {
+  if (process.env.EXPO_PUBLIC_ENV === 'production') {
+    isSupported()
+      .then((supported) => {
+        if (supported) {
+          analytics = getAnalytics(app);
+        }
+      })
+      .catch((error) => {
+        logger.warn('Failed to initialize analytics:', error);
+      });
+  } else {
+    logger.warn('Analytics disabled in non-production environment');
+  }
 } else {
-  logger.warn('Analytics disabled in non-production environment');
+  logger.warn('Analytics disabled due to missing Firebase configuration');
 }
 
 export { analytics };


### PR DESCRIPTION
## Summary
- log and disable Firebase when required environment variables are missing
- expose `firebaseEnabled` flag and avoid analytics init when config is incomplete
- document Firebase environment variables in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896796954e88327861f49a972b786cd