### PR TITLE
Handle missing Firebase in push notifications

### DIFF
--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -38,6 +38,10 @@ export default function usePushNotifications() {
       const projectId = Constants?.expoConfig?.extra?.eas?.projectId;
       const { data } = await Notifications.getExpoPushTokenAsync({ projectId });
       setToken(data);
+      if (!db) {
+        logger.warn('Firebase is unavailable; skipping push token save');
+        return;
+      }
       try {
         await updateDoc(doc(db, 'users', user.uid), { fcmToken: data });
       } catch (err) {


### PR DESCRIPTION
## Summary
- guard push token save when Firebase is unavailable

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Auth | undefined not assignable in services/auth.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68979a528d048327a0f69e5c653fa91c