### PR TITLE
chore: guard useNotifications when Firestore is unavailable

### DIFF
--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -28,6 +28,12 @@ export default function useNotifications() {
 
   useEffect(() => {
     if (!user?.uid) return;
+    if (!db) {
+      const err = new Error('Firestore not initialized');
+      logger.error(err.message);
+      setError(err);
+      return;
+    }
     const notificationsRef = collection(
       db,
       'users',
@@ -63,6 +69,12 @@ export default function useNotifications() {
 
   const markAllRead = async () => {
     if (!user?.uid) return;
+    if (!db) {
+      const err = new Error('Firestore not initialized');
+      logger.error('Error marking notifications read', err);
+      setError(err);
+      return;
+    }
     try {
       await Promise.all(
         items


### PR DESCRIPTION
## Summary
- handle missing Firestore db in notifications hook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979c0b70008327a2800fea074a912e