### PR TITLE
Validate auth before Firebase actions

### DIFF
--- a/services/auth.ts
+++ b/services/auth.ts
@@ -10,22 +10,34 @@ import {
 } from 'firebase/auth';
 import { AuthSessionResult } from 'expo-auth-session';
 
+const authNotInitialized = () =>
+  Promise.reject(new Error('Firebase auth is not initialized'));
+
 export const signUp = (email: string, password: string) =>
-  createUserWithEmailAndPassword(auth, email, password);
+  auth
+    ? createUserWithEmailAndPassword(auth, email, password)
+    : authNotInitialized();
 
 export const signIn = (email: string, password: string) =>
-  signInWithEmailAndPassword(auth, email, password);
+  auth
+    ? signInWithEmailAndPassword(auth, email, password)
+    : authNotInitialized();
 
-export const signInAnonymouslyService = () => signInAnonymously(auth);
+export const signInAnonymouslyService = () =>
+  auth ? signInAnonymously(auth) : authNotInitialized();
 
 export const resetPassword = (email: string) =>
-  sendPasswordResetEmail(auth, email);
+  auth ? sendPasswordResetEmail(auth, email) : authNotInitialized();
 
-export const signOut = () => fbSignOut(auth);
+export const signOut = () => (auth ? fbSignOut(auth) : authNotInitialized());
 
 export const signInWithGoogle = async (
   promptAsync: () => Promise<AuthSessionResult | void>,
 ) => {
+  if (!auth) {
+    return authNotInitialized();
+  }
+
   const res = await promptAsync();
   if (res && 'type' in res && res.type === 'success' && res.authentication?.idToken) {
     const credential = GoogleAuthProvider.credential(res.authentication.idToken);


### PR DESCRIPTION
## Summary
- guard auth-dependent auth.ts methods from uninitialized auth
- return descriptive rejected Promise if auth is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979cc63b748327899dfeeea725bdec