### PR TITLE
test: add analytics event logging tests

### DIFF
--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+
+describe('trackEvent', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('logs event when analytics is defined', () => {
+    const logEvent = jest.fn();
+    const warn = jest.fn();
+
+    jest.doMock('firebase/analytics', () => ({ logEvent }));
+    jest.doMock('@/shared/logger', () => ({ warn }));
+    const analyticsInstance = {};
+    jest.doMock('@/firebase', () => ({ analytics: analyticsInstance }));
+
+    const { trackEvent } = require('@/helpers/analytics');
+    trackEvent('test_event', { foo: 'bar' });
+
+    expect(logEvent).toHaveBeenCalledWith(analyticsInstance, 'test_event', { foo: 'bar' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when analytics is undefined', () => {
+    const logEvent = jest.fn();
+    const warn = jest.fn();
+
+    jest.doMock('firebase/analytics', () => ({ logEvent }));
+    jest.doMock('@/shared/logger', () => ({ warn }));
+    jest.doMock('@/firebase', () => ({ analytics: undefined }));
+
+    const { trackEvent } = require('@/helpers/analytics');
+    trackEvent('test_event');
+
+    expect(logEvent).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('Analytics not ready');
+  });
+});
+


### PR DESCRIPTION
## Summary
- test analytics event tracking to ensure logEvent is called when analytics exists
- verify warning when analytics is undefined

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68979dd2f0a08327a773340300b05c2f