### PR TITLE
chore: sync bundle identifiers and Firebase configs

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,14 +18,14 @@
     "ios": {
       "icon": "./assets/images/icon.png",
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.whisplist",
+      "bundleIdentifier": "com.zachary.whisplist",
       "infoPlist": {
         "NSMicrophoneUsageDescription": "This app uses the microphone to record wishes and confessions."
       }
     },
     "android": {
       "icon": "./assets/images/icon.png",
-      "package": "com.anonymous.whisplist",
+      "package": "com.zachary.whisplist",
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/icon.png",
         "backgroundColor": "#ffffff"

--- a/google-services.json
+++ b/google-services.json
@@ -25,7 +25,7 @@
               "client_id": "344114970536-419lkejgcl0l5dt015vv6f3d5rgmcut1.apps.googleusercontent.com",
               "client_type": 2,
               "ios_info": {
-                "bundle_id": "app.json"
+                "bundle_id": "com.zachary.whisplist"
               }
             }
           ]

--- a/ios/GoogleService-Info.plist
+++ b/ios/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CLIENT_ID</key>
+    <string>344114970536-419lkejgcl0l5dt015vv6f3d5rgmcut1.apps.googleusercontent.com</string>
+    <key>REVERSED_CLIENT_ID</key>
+    <string>com.googleusercontent.apps.344114970536-419lkejgcl0l5dt015vv6f3d5rgmcut1</string>
+    <key>API_KEY</key>
+    <string>AIzaSyAdOn4HCBCM-7qrJDZHCV0cDLPBzQlYnWM</string>
+    <key>GCM_SENDER_ID</key>
+    <string>344114970536</string>
+    <key>PLIST_VERSION</key>
+    <string>1</string>
+    <key>BUNDLE_ID</key>
+    <string>com.zachary.whisplist</string>
+    <key>PROJECT_ID</key>
+    <string>whisplist-f6b0d</string>
+    <key>STORAGE_BUCKET</key>
+    <string>whisplist-f6b0d.firebasestorage.app</string>
+    <key>IS_ADS_ENABLED</key>
+    <false/>
+    <key>IS_ANALYTICS_ENABLED</key>
+    <true/>
+    <key>IS_APPINVITE_ENABLED</key>
+    <true/>
+    <key>IS_GCM_ENABLED</key>
+    <true/>
+    <key>IS_SIGNIN_ENABLED</key>
+    <true/>
+    <key>GOOGLE_APP_ID</key>
+    <string>1:344114970536:ios:57fb55b0ef773dd081279d</string>
+    <key>DATABASE_URL</key>
+    <string></string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- set production bundle identifiers for iOS and Android
- align Firebase config package names
- add iOS `GoogleService-Info.plist` with real app ID

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Firestore | undefined is not assignable to Firestore)*

------
https://chatgpt.com/codex/tasks/task_e_6897ff0b574883279d68cf822fd5d54d