### PR TITLE
Use theme-based placeholder colors across app

### DIFF
--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -575,7 +575,7 @@ export default function Page() {
                     { backgroundColor: theme.input, color: theme.text },
                   ]}
                   placeholder="Search wishes..."
-                  placeholderTextColor="#aaa"
+                  placeholderTextColor={theme.placeholder}
                   value={searchTerm}
                   onChangeText={setSearchTerm}
                 />
@@ -596,6 +596,7 @@ export default function Page() {
                         <Text
                           style={[
                             styles.toggleText,
+                            { color: theme.placeholder },
                             activeTab === tab && styles.activeToggleText,
                           ]}
                         >
@@ -658,7 +659,7 @@ export default function Page() {
               ) : error ? (
                 <Text style={styles.errorText}>{error}</Text>
               ) : (
-                <Text style={styles.noResults}>
+                <Text style={[styles.noResults, { color: theme.placeholder }]}>
                   No wishes yet in this category. Be the first to post ✨
                 </Text>
               )
@@ -722,9 +723,7 @@ const styles = StyleSheet.create({
   activeToggle: {
     backgroundColor: '#8b5cf6',
   },
-  toggleText: {
-    color: '#aaa',
-  },
+  toggleText: {},
   activeToggleText: {
     color: '#fff',
     fontWeight: 'bold',
@@ -804,7 +803,6 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   noResults: {
-    color: '#ccc',
     textAlign: 'center',
     marginTop: 20,
   },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1109,7 +1109,7 @@ export default function Page() {
                 <TextInput
                   style={styles.input}
                   placeholder="Search wishes..."
-                  placeholderTextColor="#999"
+                  placeholderTextColor={theme.placeholder}
                   value={searchTerm}
                   onChangeText={setSearchTerm}
                 />
@@ -1135,7 +1135,7 @@ export default function Page() {
                   <TextInput
                     style={styles.input}
                     placeholder="What's your wish?"
-                    placeholderTextColor="#999"
+                    placeholderTextColor={theme.placeholder}
                     value={wish}
                     onChangeText={setWish}
                   />
@@ -1210,7 +1210,7 @@ export default function Page() {
                           <TextInput
                             style={styles.input}
                             placeholder="Option A"
-                            placeholderTextColor="#999"
+                            placeholderTextColor={theme.placeholder}
                             value={optionA}
                             onChangeText={setOptionA}
                           />
@@ -1218,7 +1218,7 @@ export default function Page() {
                           <TextInput
                             style={styles.input}
                             placeholder="Option B"
-                            placeholderTextColor="#999"
+                            placeholderTextColor={theme.placeholder}
                             value={optionB}
                             onChangeText={setOptionB}
                           />
@@ -1270,7 +1270,7 @@ export default function Page() {
                           <TextInput
                             style={styles.input}
                             placeholder="Gift link (optional)"
-                            placeholderTextColor="#999"
+                            placeholderTextColor={theme.placeholder}
                             value={giftLink}
                             onChangeText={setGiftLink}
                           />
@@ -1278,7 +1278,7 @@ export default function Page() {
                           <TextInput
                             style={styles.input}
                             placeholder="kofi, paypal, etc"
-                            placeholderTextColor="#999"
+                            placeholderTextColor={theme.placeholder}
                             value={giftType}
                             onChangeText={setGiftType}
                           />
@@ -1286,7 +1286,7 @@ export default function Page() {
                           <TextInput
                             style={styles.input}
                             placeholder="Support on Ko-fi"
-                            placeholderTextColor="#999"
+                            placeholderTextColor={theme.placeholder}
                             value={giftLabel}
                             onChangeText={setGiftLabel}
                           />

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -439,7 +439,7 @@ export default function Page() {
         value={displayName}
         onChangeText={setDisplayName}
         placeholder="Display Name"
-        placeholderTextColor={theme.text}
+        placeholderTextColor={theme.placeholder}
       />
 
       <Text style={styles.label}>Bio</Text>
@@ -448,7 +448,7 @@ export default function Page() {
         value={bio}
         onChangeText={setBio}
         placeholder="Bio"
-        placeholderTextColor={theme.text}
+        placeholderTextColor={theme.placeholder}
         multiline
       />
       <TouchableOpacity

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -505,7 +505,7 @@ export default function Page() {
                 },
               ]}
               placeholder="Send feedback"
-              placeholderTextColor="#888"
+              placeholderTextColor={theme.placeholder}
               value={feedback}
               onChangeText={setFeedback}
               multiline

--- a/app/auth/index.tsx
+++ b/app/auth/index.tsx
@@ -84,7 +84,7 @@ export default function Page() {
           { backgroundColor: theme.input, color: theme.text },
         ]}
         placeholder="Email"
-        placeholderTextColor={theme.text + '99'} // theme fix
+        placeholderTextColor={theme.placeholder}
         value={email}
         onChangeText={setEmail}
       />
@@ -94,7 +94,7 @@ export default function Page() {
           { backgroundColor: theme.input, color: theme.text },
         ]}
         placeholder="Password"
-        placeholderTextColor={theme.text + '99'} // theme fix
+        placeholderTextColor={theme.placeholder}
         secureTextEntry
         value={password}
         onChangeText={setPassword}

--- a/app/inbox.tsx
+++ b/app/inbox.tsx
@@ -17,7 +17,7 @@ export default function InboxPage() {
   const renderItem = ({ item }: any) => (
     <View style={[styles.item, { backgroundColor: theme.input }]}>
       <Text style={[styles.text, { color: theme.text }]}>{item.message}</Text>
-      <Text style={[styles.time, { color: theme.text + '99' }]}>
+      <Text style={[styles.time, { color: theme.placeholder }]}>
         {/* theme fix */}
         {item.timestamp?.seconds
           ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), {

--- a/app/journal.tsx
+++ b/app/journal.tsx
@@ -292,7 +292,7 @@ export default function JournalPage() {
           { backgroundColor: theme.input, color: theme.text },
         ]}
         placeholder="Write your thoughts"
-        placeholderTextColor={theme.text + '99'} // theme fix
+        placeholderTextColor={theme.placeholder}
         value={entry}
         onChangeText={setEntry}
         multiline
@@ -321,7 +321,7 @@ export default function JournalPage() {
                   ? item.text.slice(0, 80) + '...'
                   : item.text}
             </Text>
-            <Text style={[styles.entryDate, { color: theme.text + '99' }]}>
+            <Text style={[styles.entryDate, { color: theme.placeholder }]}> 
               {/* theme fix */}
               {item.timestamp?.seconds
                 ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), {

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -19,7 +19,7 @@ export default function NotificationsPage() {
             : '🎉'}{' '}
         {item.message}
       </Text>
-      <Text style={[styles.time, { color: theme.text + '99' }]}>
+      <Text style={[styles.time, { color: theme.placeholder }]}>
         {/* theme fix */}
         {item.timestamp?.seconds
           ? formatDistanceToNow(new Date(item.timestamp.seconds * 1000), {

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -632,7 +632,7 @@ export default function Page() {
                 onPress={() => router.push(`/profile/${item.displayName}`)}
                 hitSlop={HIT_SLOP}
               >
-                <Text style={[styles.nickname, { color: theme.text + '99' }]}>
+                <Text style={[styles.nickname, { color: theme.placeholder }]}>
                   {' '}
                   {/* theme fix */}
                   {item.displayName}
@@ -640,7 +640,7 @@ export default function Page() {
                 </Text>
               </TouchableOpacity>
             ) : (
-              <Text style={[styles.nickname, { color: theme.text + '99' }]}>
+              <Text style={[styles.nickname, { color: theme.placeholder }]}>
                 {item.nickname || 'Anonymous'}
               </Text>
             )}
@@ -693,7 +693,7 @@ export default function Page() {
                 <Text style={[styles.comment, { color: theme.text }]}> 
                   {item.text}
                 </Text>
-                <Text style={[styles.timestamp, { color: theme.text + '99' }]}> 
+                <Text style={[styles.timestamp, { color: theme.placeholder }]}> 
                   {' '}
                   {/* theme fix */}
                   {item.timestamp?.seconds
@@ -781,6 +781,7 @@ export default function Page() {
       router,
       theme.text,
       theme.tint,
+      theme.placeholder,
       verifiedStatus,
       wish?.userId,
       editingCommentId,
@@ -944,7 +945,7 @@ export default function Page() {
                           backgroundGradientFrom: theme.input,
                           backgroundGradientTo: theme.input,
                           color: () => theme.tint,
-                          labelColor: () => theme.text + '99',
+                          labelColor: () => theme.placeholder,
                         }}
                         style={{ marginTop: 10 }}
                       />
@@ -1154,7 +1155,7 @@ export default function Page() {
             </View>
           )}
 
-          <Text style={[styles.label, { color: theme.text + '99' }]}>
+          <Text style={[styles.label, { color: theme.placeholder }]}>
             Comment
           </Text>
           <TextInput
@@ -1163,7 +1164,7 @@ export default function Page() {
               { backgroundColor: theme.input, color: theme.text },
             ]}
             placeholder="Your comment"
-            placeholderTextColor={theme.text + '99'} // theme fix
+            placeholderTextColor={theme.placeholder} // theme fix
             value={comment}
             onChangeText={setComment}
           />
@@ -1174,7 +1175,7 @@ export default function Page() {
                 { backgroundColor: theme.input, color: theme.text },
               ]}
               placeholder="Nickname or emoji"
-              placeholderTextColor={theme.text + '99'} // theme fix
+              placeholderTextColor={theme.placeholder} // theme fix
               value={nickname}
               onChangeText={setNickname}
             />
@@ -1272,7 +1273,7 @@ export default function Page() {
                       },
                     ]}
                     placeholder="Wish text"
-                    placeholderTextColor={theme.text + '99'}
+                    placeholderTextColor={theme.placeholder}
                     value={editText}
                     onChangeText={setEditText}
                   />
@@ -1282,7 +1283,7 @@ export default function Page() {
                       { backgroundColor: theme.input, color: theme.text },
                     ]}
                     placeholder="Category"
-                    placeholderTextColor={theme.text + '99'}
+                    placeholderTextColor={theme.placeholder}
                     value={editCategory}
                     onChangeText={setEditCategory}
                   />
@@ -1391,7 +1392,7 @@ export default function Page() {
                       },
                     ]}
                     placeholder="Add a message (optional)"
-                    placeholderTextColor={theme.text + '99'} // theme fix
+                    placeholderTextColor={theme.placeholder} // theme fix
                     value={thanksMessage}
                     onChangeText={setThanksMessage}
                   />

--- a/components/FulfillmentLinkDialog.tsx
+++ b/components/FulfillmentLinkDialog.tsx
@@ -62,7 +62,7 @@ export default function FulfillmentLinkDialog({
           <TextInput
             style={styles.input}
             placeholder={t('fulfillment.linkPlaceholder')}
-            placeholderTextColor={theme.text + '99'} // theme fix
+            placeholderTextColor={theme.placeholder}
             value={link}
             onChangeText={setLink}
           />

--- a/components/ReferralNameDialog.tsx
+++ b/components/ReferralNameDialog.tsx
@@ -47,7 +47,7 @@ export default function ReferralNameDialog({
           <TextInput
             style={styles.input}
             placeholder={t('referral.namePlaceholder')}
-            placeholderTextColor={c.text + '99'} // theme fix
+            placeholderTextColor={c.placeholder}
             value={name}
             onChangeText={setName}
           />

--- a/components/ReportDialog.tsx
+++ b/components/ReportDialog.tsx
@@ -45,7 +45,7 @@ export default function ReportDialog({
           <TextInput
             style={styles.input}
             placeholder={t('report.reasonPlaceholder')}
-            placeholderTextColor={c.text + '99'} // theme fix
+            placeholderTextColor={c.placeholder}
             value={reason}
             onChangeText={setReason}
           />

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -15,6 +15,7 @@ export const Colors = {
     tabIconDefault: '#687076',
     tabIconSelected: tintColorLight,
     input: '#f0f0f0',
+    placeholder: '#11181C99',
   },
   dark: {
     text: '#ECEDEE',
@@ -24,6 +25,7 @@ export const Colors = {
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,
     input: '#1e1e1e',
+    placeholder: '#ECEDEE99',
   },
   sunset: {
     text: '#7c2d12',
@@ -33,6 +35,7 @@ export const Colors = {
     tabIconDefault: '#92400e',
     tabIconSelected: '#fb923c',
     input: '#fde68a',
+    placeholder: '#7c2d1299',
   },
   ocean: {
     text: '#083344',
@@ -42,6 +45,7 @@ export const Colors = {
     tabIconDefault: '#164e63',
     tabIconSelected: '#0e7490',
     input: '#a5f3fc',
+    placeholder: '#08334499',
   },
   neon: {
     text: '#F0F0F0',
@@ -51,6 +55,7 @@ export const Colors = {
     tabIconDefault: '#00ffff',
     tabIconSelected: '#ff00ff',
     input: '#333333',
+    placeholder: '#F0F0F099',
   },
   roseQuartz: {
     text: '#403635',
@@ -60,6 +65,7 @@ export const Colors = {
     tabIconDefault: '#8d6a75',
     tabIconSelected: '#bd5d82',
     input: '#f3d7d9',
+    placeholder: '#40363599',
   },
   cyberpunk: {
     text: '#e0e0e0',
@@ -69,6 +75,7 @@ export const Colors = {
     tabIconDefault: '#00ffff',
     tabIconSelected: '#ff00ff',
     input: '#1a1a1a',
+    placeholder: '#e0e0e099',
   },
   cottonCandy: {
     text: '#553c7b',
@@ -78,6 +85,7 @@ export const Colors = {
     tabIconDefault: '#8c5da7',
     tabIconSelected: '#66b2ff',
     input: '#ffdff1',
+    placeholder: '#553c7b99',
   },
   emerald: {
     text: '#064e3b',
@@ -87,6 +95,7 @@ export const Colors = {
     tabIconDefault: '#065f46',
     tabIconSelected: '#059669',
     input: '#a7f3d0',
+    placeholder: '#064e3b99',
   },
   sepia: {
     text: '#4b3413',
@@ -96,5 +105,6 @@ export const Colors = {
     tabIconDefault: '#6b4423',
     tabIconSelected: '#8b5a2b',
     input: '#e8d8c3',
+    placeholder: '#4b341399',
   },
 };


### PR DESCRIPTION
## Summary
- add `placeholder` color to theme definitions
- use `theme.placeholder` for TextInput placeholders and timestamp text
- remove hard-coded greys from feed search, settings feedback, and more

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898c5399cec83279bc027dfdfd1a56a