### PR TITLE
feat: enrich logging with user context and severity

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -8,7 +8,7 @@ import {
   getReactNativePersistence,
 } from 'firebase/auth';
 import { getAnalytics, isSupported, Analytics } from 'firebase/analytics';
-import { Platform } from 'react-native';
+import { Platform, ToastAndroid, Alert } from 'react-native';
 import * as logger from '@/shared/logger';
 
 const firebaseConfig = {
@@ -41,7 +41,18 @@ if (process.env.EXPO_PUBLIC_ENV === 'production') {
       }
     })
     .catch((error) => {
-      logger.warn('Failed to initialize analytics:', error);
+      logger.error('Failed to initialize analytics:', error, {
+        userId: auth.currentUser?.uid,
+        severity: 'high',
+      });
+      if (__DEV__) {
+        const message = `Failed to initialize analytics: ${error}`;
+        if (Platform.OS === 'android') {
+          ToastAndroid.show(message, ToastAndroid.LONG);
+        } else {
+          Alert.alert('Analytics Error', message);
+        }
+      }
     });
 } else {
   logger.warn('Analytics disabled in non-production environment');

--- a/helpers/analytics.ts
+++ b/helpers/analytics.ts
@@ -1,5 +1,5 @@
 import { logEvent } from 'firebase/analytics';
-import { analytics } from '@/firebase';
+import { analytics, auth } from '@/firebase';
 import * as logger from '../shared/logger';
 
 export function trackEvent(name: string, params?: Record<string, any>) {
@@ -7,9 +7,15 @@ export function trackEvent(name: string, params?: Record<string, any>) {
     if (analytics) {
       logEvent(analytics, name, params);
     } else {
-      logger.warn('Analytics not ready');
+      logger.warn('Analytics not ready', {
+        userId: auth.currentUser?.uid,
+        severity: 'warning',
+      });
     }
   } catch (err) {
-    logger.warn('Failed to log analytics event:', err);
+    logger.warn('Failed to log analytics event:', err, {
+      userId: auth.currentUser?.uid,
+      severity: 'error',
+    });
   }
 }

--- a/shared/logger.js
+++ b/shared/logger.js
@@ -1,8 +1,13 @@
 let telemetry = null;
 function emit(level, args) {
+  let meta;
+  const last = args[args.length - 1];
+  if (last && typeof last === 'object' && ('userId' in last || 'severity' in last)) {
+    meta = args.pop();
+  }
   if (telemetry) {
     try {
-      telemetry(level, ...args);
+      telemetry(level, meta, ...args);
     } catch {
       // ignore telemetry errors
     }

--- a/shared/logger.ts
+++ b/shared/logger.ts
@@ -1,4 +1,13 @@
-export type TelemetryFn = (level: 'log' | 'warn' | 'error', ...args: any[]) => void;
+export type TelemetryMeta = {
+  userId?: string;
+  severity?: string;
+};
+
+export type TelemetryFn = (
+  level: 'log' | 'warn' | 'error',
+  meta: TelemetryMeta | undefined,
+  ...args: any[]
+) => void;
 
 let telemetry: TelemetryFn | null = null;
 
@@ -7,13 +16,20 @@ export function setTelemetry(fn: TelemetryFn) {
 }
 
 function emit(level: 'log' | 'warn' | 'error', args: any[]) {
+  let meta: TelemetryMeta | undefined;
+  const last = args[args.length - 1];
+  if (last && typeof last === 'object' && ('userId' in last || 'severity' in last)) {
+    meta = args.pop();
+  }
+
   if (telemetry) {
     try {
-      telemetry(level, ...args);
+      telemetry(level, meta, ...args);
     } catch {
       // ignore telemetry errors
     }
   }
+
   if (process.env.NODE_ENV !== 'production') {
     console[level](...args);
   }

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -12,7 +12,10 @@ describe('trackEvent', () => {
     jest.doMock('firebase/analytics', () => ({ logEvent }));
     jest.doMock('@/shared/logger', () => ({ warn }));
     const analyticsInstance = {};
-    jest.doMock('@/firebase', () => ({ analytics: analyticsInstance }));
+    jest.doMock('@/firebase', () => ({
+      analytics: analyticsInstance,
+      auth: { currentUser: { uid: 'user1' } },
+    }));
 
     const { trackEvent } = require('@/helpers/analytics');
     trackEvent('test_event', { foo: 'bar' });
@@ -27,13 +30,19 @@ describe('trackEvent', () => {
 
     jest.doMock('firebase/analytics', () => ({ logEvent }));
     jest.doMock('@/shared/logger', () => ({ warn }));
-    jest.doMock('@/firebase', () => ({ analytics: undefined }));
+    jest.doMock('@/firebase', () => ({
+      analytics: undefined,
+      auth: { currentUser: { uid: 'user1' } },
+    }));
 
     const { trackEvent } = require('@/helpers/analytics');
     trackEvent('test_event');
 
     expect(logEvent).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledWith('Analytics not ready');
+    expect(warn).toHaveBeenCalledWith('Analytics not ready', {
+      userId: 'user1',
+      severity: 'warning',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- extend shared logger to accept userId and severity metadata
- surface analytics initialization errors via logger and dev-only toast
- include user and severity info when trackEvent logging fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aa6d2c44083279589be796bb22c99