### PR TITLE
chore: localize settings screen

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,7 +14,8 @@
   },
   "common": {
     "cancel": "Cancel",
-    "ok": "OK"
+    "ok": "OK",
+    "delete": "Delete"
   },
   "auth": {
     "errorTitle": "Authentication Error"
@@ -48,6 +49,76 @@
     "profile": "Profile",
     "inbox": "Inbox",
     "settings": "Settings"
+  },
+  "settings": {
+    "title": "Settings",
+    "sections": {
+      "privacy": "Privacy & Profile",
+      "notifications": "Notifications",
+      "developer": "Advanced / Developer",
+      "system": "System & Account",
+      "theme": "Theme"
+    },
+    "privacy": {
+      "anonymize": "Anonymize Username",
+      "publicProfile": "Public Profile Enabled",
+      "stripeGifting": "Enable Stripe Gifting"
+    },
+    "notifications": {
+      "dailyQuote": "Daily Quote",
+      "boostNotifications": "Boost Notifications",
+      "commentNotifications": "Comment Notifications",
+      "referralBonuses": "Referral Bonuses"
+    },
+    "developer": {
+      "developerMode": "Developer Mode",
+      "stats": {
+        "totalWishes": "Total Wishes: {{count}}",
+        "totalBoosts": "Total Boosts: {{count}}",
+        "totalGifts": "Total Gifts: {{count}}",
+        "activeUsers": "Active Users (past 7d): {{count}}"
+      }
+    },
+    "system": {
+      "pickAvatar": "Pick Avatar",
+      "earnedBoosts": "You've earned {{count}} free boosts!",
+      "referFriend": "Refer a Friend",
+      "defaultCategory": "Default Category",
+      "categories": {
+        "general": "General",
+        "love": "Love",
+        "career": "Career",
+        "health": "Health"
+      },
+      "language": "Language",
+      "languages": {
+        "en": "English",
+        "es": "Spanish"
+      },
+      "feedbackPlaceholder": "Send feedback",
+      "submitFeedback": "Submit Feedback",
+      "exportHistory": "Export History",
+      "rateApp": "Rate this App",
+      "permissions": "Permissions",
+      "deleteContent": "Delete My Content",
+      "resetData": "Reset App Data",
+      "aboutDescription": "WhispList promises a safe, anonymous place to share your dreams.",
+      "terms": "Terms of Service",
+      "privacy": "Privacy Policy"
+    },
+    "alert": {
+      "permissionRequiredTitle": "Permission required",
+      "permissionRequiredMessage": "Media access needed",
+      "dataCleared": "Data cleared",
+      "noNickname": "No nickname set",
+      "feedbackSent": "Feedback sent!",
+      "deleteAllTitle": "Delete All",
+      "areYouSure": "Are you sure?",
+      "contentDeleted": "Content deleted",
+      "permissionsTitle": "Permissions",
+      "permissionsStatus": "Microphone: {{mic}}\\nNotifications: {{notif}}",
+      "inviteMessage": "Join me on WhispList! {{url}}"
+    }
   },
   "notFound": {
     "title": "404 - Not Found"

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -14,7 +14,8 @@
   },
   "common": {
     "cancel": "Cancelar",
-    "ok": "Aceptar"
+    "ok": "Aceptar",
+    "delete": "Eliminar"
   },
   "auth": {
     "errorTitle": "Error de autenticación"
@@ -48,6 +49,76 @@
     "profile": "Perfil",
     "inbox": "Bandeja",
     "settings": "Ajustes"
+  },
+  "settings": {
+    "title": "Ajustes",
+    "sections": {
+      "privacy": "Privacidad y Perfil",
+      "notifications": "Notificaciones",
+      "developer": "Avanzado / Desarrollador",
+      "system": "Sistema y Cuenta",
+      "theme": "Tema"
+    },
+    "privacy": {
+      "anonymize": "Anonimizar nombre de usuario",
+      "publicProfile": "Perfil público habilitado",
+      "stripeGifting": "Habilitar regalos con Stripe"
+    },
+    "notifications": {
+      "dailyQuote": "Frase diaria",
+      "boostNotifications": "Notificaciones de impulso",
+      "commentNotifications": "Notificaciones de comentarios",
+      "referralBonuses": "Bonos por referidos"
+    },
+    "developer": {
+      "developerMode": "Modo desarrollador",
+      "stats": {
+        "totalWishes": "Deseos totales: {{count}}",
+        "totalBoosts": "Impulsos totales: {{count}}",
+        "totalGifts": "Regalos totales: {{count}}",
+        "activeUsers": "Usuarios activos (últimos 7d): {{count}}"
+      }
+    },
+    "system": {
+      "pickAvatar": "Elegir avatar",
+      "earnedBoosts": "Has ganado {{count}} impulsos gratis!",
+      "referFriend": "Referir a un amigo",
+      "defaultCategory": "Categoría predeterminada",
+      "categories": {
+        "general": "General",
+        "love": "Amor",
+        "career": "Carrera",
+        "health": "Salud"
+      },
+      "language": "Idioma",
+      "languages": {
+        "en": "Inglés",
+        "es": "Español"
+      },
+      "feedbackPlaceholder": "Enviar comentarios",
+      "submitFeedback": "Enviar comentarios",
+      "exportHistory": "Exportar historial",
+      "rateApp": "Calificar esta app",
+      "permissions": "Permisos",
+      "deleteContent": "Eliminar mi contenido",
+      "resetData": "Restablecer datos de la app",
+      "aboutDescription": "WhispList promete un lugar seguro y anónimo para compartir tus sueños.",
+      "terms": "Términos de servicio",
+      "privacy": "Política de privacidad"
+    },
+    "alert": {
+      "permissionRequiredTitle": "Se requiere permiso",
+      "permissionRequiredMessage": "Se necesita acceso a medios",
+      "dataCleared": "Datos borrados",
+      "noNickname": "No hay apodo establecido",
+      "feedbackSent": "¡Comentarios enviados!",
+      "deleteAllTitle": "Eliminar todo",
+      "areYouSure": "¿Estás seguro?",
+      "contentDeleted": "Contenido eliminado",
+      "permissionsTitle": "Permisos",
+      "permissionsStatus": "Micrófono: {{mic}}\\nNotificaciones: {{notif}}",
+      "inviteMessage": "¡Únete a mí en WhispList! {{url}}"
+    }
   },
   "notFound": {
     "title": "404 - No encontrado"


### PR DESCRIPTION
## Summary
- use i18n on settings screen, replacing hard-coded strings
- add English and Spanish resources for settings translations

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check` *(fails: Code style issues found in 34 files)*

------
https://chatgpt.com/codex/tasks/task_e_689b6da76ac883279b93a732af55bb51