### PR TITLE
fix: type viewable items callback

### DIFF
--- a/app/Onboarding.tsx
+++ b/app/Onboarding.tsx
@@ -6,6 +6,7 @@ import {
   Dimensions,
   Animated,
   TouchableOpacity,
+  ViewToken,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRouter } from 'expo-router';
@@ -38,13 +39,15 @@ export default function Page() {
   const viewConfigRef = useRef({ viewAreaCoveragePercentThreshold: 50 });
   const scrollX = useRef(new Animated.Value(0)).current;
 
-  const onViewableItemsChanged = useRef(({ viewableItems }: any) => {
-    if (viewableItems.length > 0) {
-      const idx = viewableItems[0].index || 0;
-      setIndex(idx);
-      trackEvent('view_onboarding_slide', { slideIndex: idx });
-    }
-  }).current;
+  const onViewableItemsChanged = useRef(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      if (viewableItems.length > 0) {
+        const idx = viewableItems[0].index || 0;
+        setIndex(idx);
+        trackEvent('view_onboarding_slide', { slideIndex: idx });
+      }
+    },
+  ).current;
 
   useEffect(() => {
     trackEvent('view_onboarding');


### PR DESCRIPTION
## Summary
- import `ViewToken` in onboarding view to type viewable items
- type `onViewableItemsChanged` callback for FlatList

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b7160e744832799b1f089f3837777