### PR TITLE
Handle AsyncStorage errors

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,10 +21,14 @@ function LayoutInner() {
 
   useEffect(() => {
     const check = async () => {
-      const seen = await AsyncStorage.getItem('hasSeenOnboarding');
-      const accepted = await AsyncStorage.getItem('acceptedTerms');
-      if ((!seen || !accepted) && pathname !== '/Onboarding') {
-        router.replace('/Onboarding');
+      try {
+        const seen = await AsyncStorage.getItem('hasSeenOnboarding');
+        const accepted = await AsyncStorage.getItem('acceptedTerms');
+        if ((!seen || !accepted) && pathname !== '/Onboarding') {
+          router.replace('/Onboarding');
+        }
+      } catch (err) {
+        logger.warn('Failed to load onboarding flags', err);
       }
     };
     check();


### PR DESCRIPTION
## Summary
- wrap theme persistence with try/catch and fallback to system or light theme
- guard onboarding flag reads against AsyncStorage failures

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b7295509083279bfafcfc1c435ba2