### PR TITLE
feat: configure checkout parameters dynamically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,13 @@ STRIPE_SECRET_KEY=your-stripe-secret
 
 # Stripe webhook signing secret to verify events
 STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+
+# Price in USD for boosting a wish
+EXPO_PUBLIC_BOOST_PRICE=0.5
+# Redirect URLs for boost checkout
+EXPO_PUBLIC_BOOST_SUCCESS_URL=https://example.com/success
+EXPO_PUBLIC_BOOST_CANCEL_URL=https://example.com/cancel
+
+# Redirect URLs for gift checkout
+EXPO_PUBLIC_GIFT_SUCCESS_URL=https://example.com/gift/success
+EXPO_PUBLIC_GIFT_CANCEL_URL=https://example.com/gift/cancel

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -811,6 +811,8 @@ export default function Page() {
                 item.id!,
                 amount,
                 item.userId!,
+                process.env.EXPO_PUBLIC_GIFT_SUCCESS_URL!,
+                process.env.EXPO_PUBLIC_GIFT_CANCEL_URL!,
               );
               if (res.url) await WebBrowser.openBrowserAsync(res.url);
             } catch (err) {

--- a/app/boost/[id].tsx
+++ b/app/boost/[id].tsx
@@ -91,7 +91,13 @@ export default function BoostPage() {
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ wishId: id, userId: user.uid }),
+          body: JSON.stringify({
+            wishId: id,
+            userId: user.uid,
+            amount: Number(process.env.EXPO_PUBLIC_BOOST_PRICE),
+            successUrl: process.env.EXPO_PUBLIC_BOOST_SUCCESS_URL,
+            cancelUrl: process.env.EXPO_PUBLIC_BOOST_CANCEL_URL,
+          }),
         },
       );
       const data = await resp.json();

--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -1336,6 +1336,8 @@ export default function Page() {
                               confirmGift.wishId,
                               confirmGift.amount,
                               confirmGift.recipientId,
+                              process.env.EXPO_PUBLIC_GIFT_SUCCESS_URL!,
+                              process.env.EXPO_PUBLIC_GIFT_CANCEL_URL!,
                             );
                             if (res.url)
                               await WebBrowser.openBrowserAsync(res.url);

--- a/functions/src/createCheckoutSession.ts
+++ b/functions/src/createCheckoutSession.ts
@@ -16,8 +16,8 @@ export const createCheckoutSession = functions
       return;
     }
 
-    const { wishId, userId } = req.body;
-    if (!wishId || !userId) {
+    const { wishId, userId, amount, successUrl, cancelUrl } = req.body;
+    if (!wishId || !userId || !amount || !successUrl || !cancelUrl) {
       res.status(400).send('Missing parameters');
       return;
     }
@@ -36,15 +36,15 @@ export const createCheckoutSession = functions
           {
             price_data: {
               currency: 'usd',
-              unit_amount: 50,
+              unit_amount: Math.round(amount * 100),
               product_data: { name: 'WhispList Boost' },
             },
             quantity: 1,
           },
         ],
         metadata: { wishId, userId },
-        success_url: 'https://example.com/success',
-        cancel_url: 'https://example.com/cancel',
+        success_url: successUrl,
+        cancel_url: cancelUrl,
       });
 
       await db.collection('boostPayments').doc(session.id).set({

--- a/functions/src/createGiftCheckoutSession.ts
+++ b/functions/src/createGiftCheckoutSession.ts
@@ -16,8 +16,8 @@ export const createGiftCheckoutSession = functions
       return;
     }
 
-    const { wishId, amount, recipientId } = req.body;
-    if (!wishId || !amount || !recipientId) {
+    const { wishId, amount, recipientId, successUrl, cancelUrl } = req.body;
+    if (!wishId || !amount || !recipientId || !successUrl || !cancelUrl) {
       res.status(400).send('Missing parameters');
       return;
     }
@@ -54,8 +54,8 @@ export const createGiftCheckoutSession = functions
           transfer_data: { destination: stripeAccountId },
         },
         metadata: { wishId, recipientId },
-        success_url: 'https://example.com/gift/success',
-        cancel_url: 'https://example.com/gift/cancel',
+        success_url: successUrl,
+        cancel_url: cancelUrl,
       });
 
       await db

--- a/helpers/wishes.ts
+++ b/helpers/wishes.ts
@@ -208,13 +208,19 @@ export async function boostWish(id: string, hours: number) {
   return updateDoc(ref, { boostedUntil });
 }
 
-export async function createBoostCheckout(wishId: string, userId: string) {
+export async function createBoostCheckout(
+  wishId: string,
+  userId: string,
+  amount: number,
+  successUrl: string,
+  cancelUrl: string,
+) {
   const resp = await fetch(
     `https://us-central1-${process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID}.cloudfunctions.net/createCheckoutSession`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ wishId, userId }),
+      body: JSON.stringify({ wishId, userId, amount, successUrl, cancelUrl }),
     },
   );
   return (await resp.json()) as { url: string; sessionId: string };
@@ -224,13 +230,21 @@ export async function createGiftCheckout(
   wishId: string,
   amount: number,
   recipientId: string,
+  successUrl: string,
+  cancelUrl: string,
 ) {
   const resp = await fetch(
     `https://us-central1-${process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID}.cloudfunctions.net/createGiftCheckoutSession`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ wishId, amount, recipientId }),
+      body: JSON.stringify({
+        wishId,
+        amount,
+        recipientId,
+        successUrl,
+        cancelUrl,
+      }),
     },
   );
   return (await resp.json()) as { url: string };

--- a/tests/wishes.test.ts
+++ b/tests/wishes.test.ts
@@ -139,14 +139,26 @@ describe('checkout helpers', () => {
       json: async () => ({ url: 'http://boost', sessionId: 'sess' }),
     });
 
-    const result = await createBoostCheckout('wish1', 'user1');
+    const result = await createBoostCheckout(
+      'wish1',
+      'user1',
+      5,
+      'http://success',
+      'http://cancel',
+    );
 
     expect(global.fetch).toHaveBeenCalledWith(
       'https://us-central1-testproj.cloudfunctions.net/createCheckoutSession',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ wishId: 'wish1', userId: 'user1' }),
+        body: JSON.stringify({
+          wishId: 'wish1',
+          userId: 'user1',
+          amount: 5,
+          successUrl: 'http://success',
+          cancelUrl: 'http://cancel',
+        }),
       },
     );
     expect(result).toEqual({ url: 'http://boost', sessionId: 'sess' });
@@ -157,14 +169,26 @@ describe('checkout helpers', () => {
       json: async () => ({ url: 'http://gift' }),
     });
 
-    const result = await createGiftCheckout('wish1', 5, 'user2');
+    const result = await createGiftCheckout(
+      'wish1',
+      5,
+      'user2',
+      'http://gift-success',
+      'http://gift-cancel',
+    );
 
     expect(global.fetch).toHaveBeenCalledWith(
       'https://us-central1-testproj.cloudfunctions.net/createGiftCheckoutSession',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ wishId: 'wish1', amount: 5, recipientId: 'user2' }),
+        body: JSON.stringify({
+          wishId: 'wish1',
+          amount: 5,
+          recipientId: 'user2',
+          successUrl: 'http://gift-success',
+          cancelUrl: 'http://gift-cancel',
+        }),
       },
     );
     expect(result).toEqual({ url: 'http://gift' });


### PR DESCRIPTION
## Summary
- allow Cloud Functions to read checkout amount and redirect URLs from the request
- document env vars for checkout price and redirect URLs
- send checkout parameters from client helpers and screens

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b7bd653748327a876e1183d20dfd0