### PR TITLE
refactor: add typed reaction updates

### DIFF
--- a/helpers/analytics.ts
+++ b/helpers/analytics.ts
@@ -2,7 +2,7 @@ import { logEvent } from 'firebase/analytics';
 import { analytics, auth } from '@/firebase';
 import * as logger from '../shared/logger';
 
-export function trackEvent(name: string, params?: Record<string, any>) {
+export function trackEvent(name: string, params?: Record<string, unknown>) {
   try {
     if (analytics) {
       logEvent(analytics, name, params);


### PR DESCRIPTION
## Summary
- define explicit reaction update mapping for `updateWishReaction`
- remove `any` usage from helpers including analytics tracking and pagination

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b8325bbc48327acd8697092efcaa7