### PR TITLE
Stop audio recorder on unmount

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -159,6 +159,22 @@ export default function Page() {
   }, []);
 
   useEffect(() => {
+    return () => {
+      if (recording) {
+        recording
+          .stop()
+          .catch((err) =>
+            logger.warn('Failed to stop recording on unmount', err),
+          );
+        setRecording(null);
+        setRecordedUri(null);
+        setIsRecording(false);
+        setIncludeAudio(false);
+      }
+    };
+  }, [recording]);
+
+  useEffect(() => {
     const load = async () => {
       setLoading(true);
       try {


### PR DESCRIPTION
## Summary
- clean up active audio recording on home tab unmount
- reset recording-related state to prevent orphaned audio

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689b8564afc0832789542bf9fbeeea81