### PR TITLE
Add tests for checkout sessions and notifications

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -60,6 +60,8 @@ async function sendPush(
   return null;
 }
 
+export const __test = { sendPush };
+
 export const notifyWishLike = functions.firestore
   .document('wishes/{wishId}')
   .onUpdate(async (change) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "babel-plugin-module-resolver": "^5.0.2",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
+        "husky": "^8.0.0",
         "jest": "^29.7.0",
         "jest-expo": "^53.0.9",
         "prettier": "^3.6.2",
@@ -11146,6 +11147,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
     "babel-plugin-module-resolver": "^5.0.2",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
+    "husky": "^8.0.0",
     "jest": "^29.7.0",
     "jest-expo": "^53.0.9",
     "prettier": "^3.6.2",
     "react-test-renderer": "19.1.1",
-    "typescript": "~5.8.3",
-    "husky": "^8.0.0"
+    "typescript": "~5.8.3"
   },
   "jest": {
     "preset": "jest-expo",

--- a/tests/createCheckoutSession.test.ts
+++ b/tests/createCheckoutSession.test.ts
@@ -1,0 +1,72 @@
+jest.mock(
+  'firebase-functions',
+  () => ({
+    runWith: jest.fn().mockReturnValue({
+      https: { onRequest: (handler: any) => handler },
+    }),
+  }),
+  { virtual: true },
+);
+
+const mockStripeCreate = jest.fn();
+jest.mock(
+  'stripe',
+  () =>
+    jest.fn().mockImplementation(() => ({
+      checkout: { sessions: { create: mockStripeCreate } },
+    })),
+  { virtual: true },
+);
+
+jest.mock(
+  'firebase-admin',
+  () => ({
+    __esModule: true,
+    initializeApp: jest.fn(),
+    firestore: () => ({
+      collection: () => ({ doc: () => ({ set: jest.fn() }) }),
+    }),
+  }),
+  { virtual: true },
+);
+
+jest.mock('../functions/src/secrets', () => ({
+  STRIPE_SECRET_KEY: { value: jest.fn(() => 'sk_test') },
+}));
+
+import { createCheckoutSession } from '../functions/src/createCheckoutSession';
+
+describe('createCheckoutSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates stripe session and returns url', async () => {
+    mockStripeCreate.mockResolvedValue({ id: 'sess_1', url: 'https://sesh' });
+    const req: any = {
+      method: 'POST',
+      body: {
+        wishId: 'w1',
+        userId: 'u1',
+        amount: 5,
+        successUrl: 's',
+        cancelUrl: 'c',
+      },
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
+    await createCheckoutSession(req, res);
+    expect(mockStripeCreate).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ url: 'https://sesh', sessionId: 'sess_1' });
+  });
+
+  it('returns 400 when missing parameters', async () => {
+    const req: any = {
+      method: 'POST',
+      body: { wishId: 'w1', userId: 'u1', successUrl: 's', cancelUrl: 'c' },
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
+    await createCheckoutSession(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('Missing parameters');
+  });
+});

--- a/tests/createGiftCheckoutSession.test.ts
+++ b/tests/createGiftCheckoutSession.test.ts
@@ -1,0 +1,90 @@
+jest.mock(
+  'firebase-functions',
+  () => ({
+    runWith: jest.fn().mockReturnValue({
+      https: { onRequest: (handler: any) => handler },
+    }),
+  }),
+  { virtual: true },
+);
+
+const mockStripeCreate = jest.fn();
+jest.mock(
+  'stripe',
+  () =>
+    jest.fn().mockImplementation(() => ({
+      checkout: { sessions: { create: mockStripeCreate } },
+    })),
+  { virtual: true },
+);
+
+const mockUserGet = jest.fn();
+jest.mock(
+  'firebase-admin',
+  () => ({
+    __esModule: true,
+    initializeApp: jest.fn(),
+    firestore: () => ({
+      collection: (name: string) => {
+        if (name === 'users') {
+          return { doc: () => ({ get: mockUserGet }) };
+        }
+        return {
+          doc: () => ({
+            collection: () => ({ doc: () => ({ set: jest.fn() }) }),
+          }),
+        };
+      },
+    }),
+  }),
+  { virtual: true },
+);
+
+jest.mock('../functions/src/secrets', () => ({
+  STRIPE_SECRET_KEY: { value: jest.fn(() => 'sk_test') },
+}));
+
+import { createGiftCheckoutSession } from '../functions/src/createGiftCheckoutSession';
+
+describe('createGiftCheckoutSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates stripe gift session and returns url', async () => {
+    mockUserGet.mockResolvedValue({ get: (f: string) => (f === 'stripeAccountId' ? 'acct_1' : undefined) });
+    mockStripeCreate.mockResolvedValue({ id: 'sess_g1', url: 'https://gift' });
+    const req: any = {
+      method: 'POST',
+      body: {
+        wishId: 'w1',
+        recipientId: 'rec1',
+        amount: 20,
+        successUrl: 's',
+        cancelUrl: 'c',
+      },
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
+    await createGiftCheckoutSession(req, res);
+    expect(mockStripeCreate).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ url: 'https://gift' });
+  });
+
+  it('returns 400 when recipient lacks stripe account', async () => {
+    mockUserGet.mockResolvedValue({ get: () => undefined });
+    const req: any = {
+      method: 'POST',
+      body: {
+        wishId: 'w1',
+        recipientId: 'rec1',
+        amount: 20,
+        successUrl: 's',
+        cancelUrl: 'c',
+      },
+    };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() } as any;
+    await createGiftCheckoutSession(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('Recipient not enabled for Stripe');
+  });
+});

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,86 @@
+jest.mock(
+  'firebase-functions',
+  () => ({
+    firestore: {
+      document: jest.fn(() => ({ onUpdate: jest.fn(), onCreate: jest.fn() })),
+    },
+    pubsub: { schedule: jest.fn(() => ({ onRun: jest.fn() })) },
+    runWith: jest.fn().mockReturnValue({ https: { onRequest: (h: any) => h } }),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'firebase-functions/params',
+  () => ({
+    defineSecret: jest.fn(() => ({ value: jest.fn(() => 'secret') })),
+  }),
+  { virtual: true },
+);
+
+jest.mock('stripe', () => jest.fn(), { virtual: true });
+
+jest.mock(
+  'firebase-functions/v2/https',
+  () => ({ onRequest: (h: any) => h }),
+  { virtual: true },
+);
+
+jest.mock('expo-server-sdk', () => ({ Expo: class {} }), { virtual: true });
+
+const mockMessagingSend = jest.fn();
+const mockMetaSet = jest.fn();
+const mockUserRef = {
+  get: jest.fn().mockResolvedValue({
+    get: (f: string) => (f === 'fcmToken' ? 'FcmToken' : undefined),
+  }),
+  collection: () => ({
+    doc: () => ({
+      get: jest.fn().mockResolvedValue({ exists: false }),
+      set: mockMetaSet,
+    }),
+  }),
+};
+jest.mock(
+  'firebase-admin',
+  () => ({
+    __esModule: true,
+    initializeApp: jest.fn(),
+    firestore: Object.assign(
+      () => ({ collection: () => ({ doc: () => mockUserRef }) }),
+      { FieldValue: { serverTimestamp: jest.fn() } },
+    ),
+    messaging: jest.fn(() => ({ send: mockMessagingSend })),
+  }),
+  { virtual: true },
+);
+
+import * as logger from '../shared/logger.ts';
+jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+import { __test } from '../functions/src/index';
+const { sendPush } = __test;
+
+describe('sendPush', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends notification via FCM token', async () => {
+    await sendPush('user1', 'Title', 'Body');
+    expect(mockMessagingSend).toHaveBeenCalledWith({
+      token: 'FcmToken',
+      notification: { title: 'Title', body: 'Body' },
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs error when FCM send fails', async () => {
+    mockMessagingSend.mockRejectedValueOnce(new Error('fcm fail'));
+    await sendPush('user1', 'Title', 'Body');
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error sending FCM notification',
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for checkout and gift checkout sessions
- cover notification dispatch and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b878d60008327af87f223f23e6f1b