### PR TITLE
refactor: extract home screen logic into hooks

### DIFF
--- a/hooks/useAudioRecorder.ts
+++ b/hooks/useAudioRecorder.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { Alert } from 'react-native';
+import { createRecorder, type AudioRecorder } from 'expo-audio';
+import * as ExpoAudio from 'expo-audio';
+import * as logger from '@/shared/logger';
+
+export const useAudioRecorder = () => {
+  const [recording, setRecording] = useState<AudioRecorder | null>(null);
+  const [recordedUri, setRecordedUri] = useState<string | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [includeAudio, setIncludeAudio] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (recording) {
+        recording
+          .stop()
+          .catch((err) => logger.warn('Failed to stop recording on unmount', err));
+        setRecording(null);
+        setRecordedUri(null);
+        setIsRecording(false);
+        setIncludeAudio(false);
+      }
+    };
+  }, [recording]);
+
+  const startRecording = async () => {
+    try {
+      const { granted } = await (ExpoAudio as any).requestRecordingPermissionsAsync();
+      if (!granted) {
+        Alert.alert('Permission required', 'Microphone access is needed to record');
+        return;
+      }
+      await (ExpoAudio as any).setAudioModeAsync({
+        allowsRecording: true,
+        interruptionMode: (ExpoAudio as any).INTERRUPTION_MODE_IOS_DO_NOT_MIX,
+        playsInSilentMode: true,
+        interruptionModeAndroid: (ExpoAudio as any).INTERRUPTION_MODE_ANDROID_DO_NOT_MIX,
+        shouldPlayInBackground: false,
+        shouldRouteThroughEarpiece: false,
+      });
+      const rec = createRecorder();
+      await rec.start();
+      setRecording(rec);
+      setIsRecording(true);
+    } catch (err) {
+      logger.error('❌ Failed to start recording:', err);
+    }
+  };
+
+  const stopRecording = async () => {
+    try {
+      if (!recording) return;
+      const { uri } = await recording.stop();
+      setRecordedUri(uri);
+    } catch (err) {
+      logger.error('❌ Failed to stop recording:', err);
+    } finally {
+      setIsRecording(false);
+      setRecording(null);
+    }
+  };
+
+  const reset = () => {
+    setRecording(null);
+    setRecordedUri(null);
+    setIsRecording(false);
+    setIncludeAudio(false);
+  };
+
+  return {
+    recording,
+    recordedUri,
+    isRecording,
+    includeAudio,
+    setIncludeAudio,
+    startRecording,
+    stopRecording,
+    reset,
+  };
+};
+
+export default useAudioRecorder;

--- a/hooks/useFeedLoader.ts
+++ b/hooks/useFeedLoader.ts
@@ -1,0 +1,147 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  collection,
+  getDocs,
+  orderBy,
+  query,
+  where,
+  limit,
+  startAfter,
+} from 'firebase/firestore';
+import { getFollowingIds } from '@/helpers/followers';
+import { cleanupExpiredWishes } from '@/helpers/wishes';
+import { Wish } from '@/types/Wish';
+import { db } from '@/firebase';
+import * as logger from '@/shared/logger';
+
+export const useFeedLoader = (user: any) => {
+  const [wishList, setWishList] = useState<Wish[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastDoc, setLastDoc] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    cleanupExpiredWishes();
+    const load = async () => {
+      setLoading(true);
+      try {
+        const following = user ? await getFollowingIds(user.uid) : [];
+        const now = new Date();
+        const boostedSnap = await getDocs(
+          query(
+            collection(db, 'wishes'),
+            where('boostedUntil', '>', now),
+            orderBy('boostedUntil', 'desc'),
+          ),
+        );
+        const boosted = boostedSnap.docs.map((d) => ({
+          id: d.id,
+          ...(d.data() as Omit<Wish, 'id'>),
+        })) as Wish[];
+        let normal: Wish[] = [];
+        if (following.length) {
+          const q = query(
+            collection(db, 'wishes'),
+            where('userId', 'in', following),
+            orderBy('timestamp', 'desc'),
+            limit(20),
+          );
+          const snap = await getDocs(q);
+          setLastDoc(snap.docs[snap.docs.length - 1] || null);
+          normal = snap.docs.map((d) => ({
+            id: d.id,
+            ...(d.data() as Omit<Wish, 'id'>),
+          })) as Wish[];
+        }
+        setWishList([...boosted, ...normal]);
+        setError(null);
+      } catch (err) {
+        logger.warn('Failed to load wishes', err);
+        setError("Couldn't load data. Check your connection and try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [user]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const followingIds = user ? await getFollowingIds(user.uid) : [];
+      const now = new Date();
+      const boostedSnap = await getDocs(
+        query(
+          collection(db, 'wishes'),
+          where('boostedUntil', '>', now),
+          orderBy('boostedUntil', 'desc'),
+        ),
+      );
+      const boosted = boostedSnap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as Omit<Wish, 'id'>),
+      })) as Wish[];
+      let normal: Wish[] = [];
+      if (user && followingIds.length) {
+        const normalSnap = await getDocs(
+          query(
+            collection(db, 'wishes'),
+            where('userId', 'in', followingIds),
+            orderBy('timestamp', 'desc'),
+            limit(20),
+          ),
+        );
+        setLastDoc(normalSnap.docs[normalSnap.docs.length - 1] || null);
+        normal = normalSnap.docs.map((d) => ({
+          id: d.id,
+          ...(d.data() as Omit<Wish, 'id'>),
+        })) as Wish[];
+      }
+      setWishList([...boosted, ...normal]);
+      setError(null);
+    } catch (err) {
+      logger.error('❌ Failed to refresh wishes:', err);
+      setError("Couldn't load data. Check your connection and try again.");
+    } finally {
+      setRefreshing(false);
+    }
+  }, [user]);
+
+  const loadMore = useCallback(async () => {
+    if (!lastDoc) return;
+    try {
+      const followingIds = user ? await getFollowingIds(user.uid) : [];
+      if (!followingIds.length) return;
+      const snap = await getDocs(
+        query(
+          collection(db, 'wishes'),
+          where('userId', 'in', followingIds),
+          orderBy('timestamp', 'desc'),
+          startAfter(lastDoc),
+          limit(20),
+        ),
+      );
+      setLastDoc(snap.docs[snap.docs.length - 1] || lastDoc);
+      const more = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as Omit<Wish, 'id'>),
+      })) as Wish[];
+      setWishList((prev) => [...prev, ...more]);
+    } catch (err) {
+      logger.warn('Failed to load more wishes', err);
+      setError("Couldn't load data. Check your connection and try again.");
+    }
+  }, [lastDoc, user]);
+
+  return {
+    wishList,
+    loading,
+    error,
+    refreshing,
+    onRefresh,
+    loadMore,
+  };
+};
+
+export default useFeedLoader;

--- a/hooks/useWishComposer.ts
+++ b/hooks/useWishComposer.ts
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { Alert, Platform, ToastAndroid } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as logger from '@/shared/logger';
+
+export const useWishComposer = (stripeEnabled?: string | false) => {
+  const [wish, setWish] = useState('');
+  const [postType, setPostType] = useState<'wish' | 'confession' | 'advice' | 'dream'>('wish');
+  const [isPoll, setIsPoll] = useState(false);
+  const [optionA, setOptionA] = useState('');
+  const [optionB, setOptionB] = useState('');
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [giftLink, setGiftLink] = useState('');
+  const [giftType, setGiftType] = useState('');
+  const [giftLabel, setGiftLabel] = useState('');
+  const [posting, setPosting] = useState(false);
+  const [postConfirm, setPostConfirm] = useState(false);
+  const [autoDelete, setAutoDelete] = useState(false);
+  const [rephrasing, setRephrasing] = useState(false);
+  const [useProfilePost, setUseProfilePost] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [enableExternalGift, setEnableExternalGift] = useState(!stripeEnabled);
+
+  const pickImage = async () => {
+    const { granted } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!granted) {
+      Alert.alert('Permission required', 'Media access is needed to select images');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled && result.assets.length > 0) {
+      setSelectedImage(result.assets[0].uri);
+    }
+  };
+
+  const resetComposer = () => {
+    setWish('');
+    setPostType('wish');
+    setIsPoll(false);
+    setOptionA('');
+    setOptionB('');
+    setSelectedImage(null);
+    setGiftLink('');
+    setGiftType('');
+    setGiftLabel('');
+    setPosting(false);
+    setAutoDelete(false);
+    setUseProfilePost(false);
+    setShowAdvanced(false);
+    setEnableExternalGift(!stripeEnabled);
+    setRephrasing(false);
+  };
+
+  const updateStreak = async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const lastDate = await AsyncStorage.getItem('lastPostedDate');
+    let streak = parseInt((await AsyncStorage.getItem('streakCount')) || '0', 10);
+    if (lastDate === today) return streak;
+    if (lastDate) {
+      const diff = (new Date(today).getTime() - new Date(lastDate).getTime()) / 86400000;
+      streak = diff === 1 ? streak + 1 : 1;
+    } else {
+      streak = 1;
+    }
+    await AsyncStorage.setItem('lastPostedDate', today);
+    await AsyncStorage.setItem('streakCount', streak.toString());
+    return streak;
+  };
+
+  const handleRephrase = async () => {
+    if (wish.trim() === '') return;
+    const originalWishText = wish;
+    setRephrasing(true);
+    try {
+      const url = `https://us-central1-${process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID}.cloudfunctions.net/rephraseWish`;
+      let attempt = 0;
+      let response: Response | null = null;
+      while (attempt < 3) {
+        response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: originalWishText }),
+        });
+        if (response.status !== 429) break;
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt++)));
+      }
+      if (!response || !response.ok) throw new Error('rephrase_failed');
+      const data = await response.json();
+      setWish(data.rephrased || originalWishText);
+    } catch (err) {
+      logger.error('Failed to rephrase wish', err);
+      const msg = 'Failed to rephrase. Please try again later.';
+      if (Platform.OS === 'android') {
+        ToastAndroid.show(msg, ToastAndroid.SHORT);
+      } else {
+        Alert.alert(msg);
+      }
+    } finally {
+      setRephrasing(false);
+    }
+  };
+
+  return {
+    wish,
+    setWish,
+    postType,
+    setPostType,
+    isPoll,
+    setIsPoll,
+    optionA,
+    setOptionA,
+    optionB,
+    setOptionB,
+    selectedImage,
+    pickImage,
+    giftLink,
+    setGiftLink,
+    giftType,
+    setGiftType,
+    giftLabel,
+    setGiftLabel,
+    posting,
+    setPosting,
+    postConfirm,
+    setPostConfirm,
+    autoDelete,
+    setAutoDelete,
+    rephrasing,
+    handleRephrase,
+    updateStreak,
+    useProfilePost,
+    setUseProfilePost,
+    showAdvanced,
+    setShowAdvanced,
+    enableExternalGift,
+    setEnableExternalGift,
+    resetComposer,
+  };
+};
+
+export default useWishComposer;


### PR DESCRIPTION
## Summary
- encapsulate wish composition state and helpers in `useWishComposer`
- centralize audio recording logic in `useAudioRecorder`
- manage feed data fetching via `useFeedLoader`
- simplify home tab by consuming new hooks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8bbfd12c8327b70daacf902e4dd2