### PR TITLE
Add error boundary to root layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { AppContainer } from '@/components/AppContainer';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AuthSessionProvider, useAuthSession } from '@/contexts/AuthSessionContext';
 import { AuthFlowsProvider } from '@/contexts/AuthFlowsContext';
 import { ReferralProvider } from '@/contexts/ReferralContext';
@@ -40,20 +41,22 @@ function LayoutInner() {
 
 export default function Layout() {
   return (
-    <AuthSessionProvider>
-      <AuthFlowsProvider>
-        <ReferralProvider>
-          <I18nProvider>
-            <ThemeProvider>
-              <SavedWishesProvider>
-                <AppContainer>
-                  <LayoutInner />
-                </AppContainer>
-              </SavedWishesProvider>
-            </ThemeProvider>
-          </I18nProvider>
-        </ReferralProvider>
-      </AuthFlowsProvider>
-    </AuthSessionProvider>
+    <ErrorBoundary>
+      <AuthSessionProvider>
+        <AuthFlowsProvider>
+          <ReferralProvider>
+            <I18nProvider>
+              <ThemeProvider>
+                <SavedWishesProvider>
+                  <AppContainer>
+                    <LayoutInner />
+                  </AppContainer>
+                </SavedWishesProvider>
+              </ThemeProvider>
+            </I18nProvider>
+          </ReferralProvider>
+        </AuthFlowsProvider>
+      </AuthSessionProvider>
+    </ErrorBoundary>
   );
 }

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { ThemedText } from './ThemedText';
+import { ThemedView } from './ThemedView';
+import * as logger from '@/shared/logger';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logger.error('Uncaught error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ThemedView style={styles.container}>
+          <ThemedText>Something went wrong.</ThemedText>
+        </ThemedView>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- add reusable `ErrorBoundary` component with fallback UI and error telemetry
- wrap app root layout with `ErrorBoundary`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find name 'lastDoc' and missing modules in functions source)*

------
https://chatgpt.com/codex/tasks/task_e_689b909012248327bb5c4b01b6ae32dd