### PR TITLE
Restrict gift writes and test access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,12 @@ service cloud.firestore {
       return request.auth != null;
     }
 
+    function wishOwner(wishId) {
+      return signedIn() &&
+        get(/databases/$(database)/documents/wishes/$(wishId)).data.userId ==
+        request.auth.uid;
+    }
+
   // User profile documents
   // Anyone can read a public profile. Writes remain restricted to the owner
   match /users/{uid} {
@@ -55,8 +61,9 @@ service cloud.firestore {
       }
 
       match /gifts/{giftId} {
-        allow read: if true;
-        allow write: if signedIn();
+        allow read: if wishOwner(wishId) || (signedIn() && request.auth.uid == resource.data.recipientId);
+        allow create: if wishOwner(wishId) || (signedIn() && request.auth.uid == request.resource.data.recipientId);
+        allow update, delete: if wishOwner(wishId) || (signedIn() && request.auth.uid == resource.data.recipientId);
       }
 
       // Reactions stored under each wish
@@ -70,10 +77,6 @@ service cloud.firestore {
       }
     }
 
-    match /gifts/{giftId} {
-      allow write: if signedIn();
-      allow read: if signedIn();
-    }
 
     // Referral records for tracking invites
     match /referrals/{referralId} {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.8",
         "expo-web-browser": "~14.2.0",
-        "firebase": "^11.0.0",
+        "firebase": "^12.1.0",
         "i18next": "^25.3.2",
         "react": "19.1.1",
         "react-dom": "19.1.1",
@@ -61,6 +61,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@expo/ngrok": "^4.1.3",
+        "@firebase/rules-unit-testing": "^4.0.1",
         "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.2.2",
         "@types/jest": "^29.5.14",
@@ -2876,19 +2877,19 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.1.tgz",
-      "integrity": "sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.1.0.tgz",
+      "integrity": "sha512-4HvFr4YIzNFh0MowJLahOjJDezYSTjQar0XYVu/sAycoxQ+kBsfXuTPRLVXCYfMR5oNwQgYe4Q2gAOYKKqsOyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -2896,15 +2897,15 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.17",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.17.tgz",
-      "integrity": "sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg==",
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.18.tgz",
+      "integrity": "sha512-iN7IgLvM06iFk8BeFoWqvVpRFW3Z70f+Qe2PfCJ7vPIgLPjHXDE774DhCT5Y2/ZU/ZbXPDPD60x/XPWEoZLNdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2912,15 +2913,15 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.23.tgz",
-      "integrity": "sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.24.tgz",
+      "integrity": "sha512-jE+kJnPG86XSqGQGhXXYt1tpTbCTED8OQJ/PQ90SEw14CuxRxx/H+lFbWA1rlFtFSsTCptAJtgyRBwr/f00vsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.17",
+        "@firebase/analytics": "0.10.18",
         "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2934,54 +2935,54 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
-      "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.1.tgz",
+      "integrity": "sha512-jxTrDbxnGoX7cGz7aP9E7v9iKvBbQfZ8Gz4TH3SfrrkcyIojJM3+hJnlbGnGxHrABts844AxRcg00arMZEyA6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.10.1.tgz",
-      "integrity": "sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
+      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.26.tgz",
-      "integrity": "sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
+      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.10.1",
+        "@firebase/app-check": "0.11.0",
         "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3000,19 +3001,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
-      "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.1.tgz",
+      "integrity": "sha512-BEy1L6Ufd85ZSP79HDIv0//T9p7d5Bepwy+2mKYkgdXBGKTbFm2e2KxyF1nq4zSQ6RRBxWi0IY0zFVmoBTZlUA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.13.2",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/app": "0.14.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/app-types": {
@@ -3022,18 +3023,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.8.tgz",
-      "integrity": "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -3046,19 +3047,19 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.28.tgz",
-      "integrity": "sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
+      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.10.8",
+        "@firebase/auth": "1.11.0",
         "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3081,28 +3082,28 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
-      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.10.tgz",
-      "integrity": "sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
+      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3110,85 +3111,85 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.20.tgz",
-      "integrity": "sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.11.tgz",
-      "integrity": "sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/database": "1.0.20",
-        "@firebase/database-types": "1.0.15",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.15.tgz",
-      "integrity": "sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.12.1"
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.8.0.tgz",
-      "integrity": "sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.0.tgz",
+      "integrity": "sha512-5zl0+/h1GvlCSLt06RMwqFsd7uqRtnNZt4sW99k2rKRd6k/ECObIWlEnvthm2cuOSnUmwZknFqtmd1qyYSLUuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "@firebase/webchannel-wrapper": "1.0.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "@firebase/webchannel-wrapper": "1.0.4",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.53",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.53.tgz",
-      "integrity": "sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.0.tgz",
+      "integrity": "sha512-4O7v4VFeSEwAZtLjsaj33YrMHMRjplOIYC2CiYsF6o/MboOhrhe01VrTt8iY9Y5EwjRHuRz4pS6jMBT8LfQYJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/firestore": "4.8.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/firestore": "4.9.0",
         "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3205,39 +3206,39 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.9.tgz",
-      "integrity": "sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.0.tgz",
+      "integrity": "sha512-2/LH5xIbD8aaLOWSFHAwwAybgSzHIM0dB5oVOL0zZnxFG1LctX2bc1NIAaPk1T+Zo9aVkLKUlB5fTXTkVUQprQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
+        "@firebase/component": "0.7.0",
         "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.26.tgz",
-      "integrity": "sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.0.tgz",
+      "integrity": "sha512-VPgtvoGFywWbQqtvgJnVWIDFSHV1WE6Hmyi5EGI+P+56EskiGkmnw6lEqc/MEUfGpPGdvmc4I9XMU81uj766/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/functions": "0.12.9",
+        "@firebase/component": "0.7.0",
+        "@firebase/functions": "0.13.0",
         "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3250,13 +3251,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.18.tgz",
-      "integrity": "sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A==",
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
+      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -3265,15 +3266,15 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.18.tgz",
-      "integrity": "sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
+      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
         "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3290,27 +3291,27 @@
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
-      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.22.tgz",
-      "integrity": "sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og==",
+      "version": "0.12.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
+      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
         "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -3319,14 +3320,14 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.22.tgz",
-      "integrity": "sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
+      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/messaging": "0.12.22",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3340,15 +3341,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.7.tgz",
-      "integrity": "sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
+      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -3357,16 +3358,16 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.20.tgz",
-      "integrity": "sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
+      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/performance": "0.7.7",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.9",
         "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3380,15 +3381,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.5.tgz",
-      "integrity": "sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.6.tgz",
+      "integrity": "sha512-Yelp5xd8hM4NO1G1SuWrIk4h5K42mNwC98eWZ9YLVu6Z0S6hFk1mxotAdCRmH2luH8FASlYgLLq6OQLZ4nbnCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3396,16 +3397,16 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.18.tgz",
-      "integrity": "sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.19.tgz",
+      "integrity": "sha512-y7PZAb0l5+5oIgLJr88TNSelxuASGlXyAKj+3pUc4fDuRIdPNBoONMHaIUa9rlffBR5dErmaD2wUBJ7Z1a513Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/remote-config": "0.6.5",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.6.6",
         "@firebase/remote-config-types": "0.4.0",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -3418,37 +3419,50 @@
       "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
       "license": "Apache-2.0"
     },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
+      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^11.0.0"
+      }
+    },
     "node_modules/@firebase/storage": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.14.tgz",
-      "integrity": "sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
+      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.24.tgz",
-      "integrity": "sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
+      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/storage": "0.13.14",
+        "@firebase/component": "0.7.0",
+        "@firebase/storage": "0.14.0",
         "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -3465,22 +3479,22 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
-      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
-      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.4.tgz",
+      "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@grpc/grpc-js": {
@@ -8500,6 +8514,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10419,39 +10444,39 @@
       }
     },
     "node_modules/firebase": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.10.0.tgz",
-      "integrity": "sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.1.0.tgz",
+      "integrity": "sha512-oZucxvfWKuAW4eHHRqGKzC43fLiPqPwHYBHPRNsnkgonqYaq0VurYgqgBosRlEulW+TWja/5Tpo2FpUU+QrfEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "1.4.1",
-        "@firebase/analytics": "0.10.17",
-        "@firebase/analytics-compat": "0.2.23",
-        "@firebase/app": "0.13.2",
-        "@firebase/app-check": "0.10.1",
-        "@firebase/app-check-compat": "0.3.26",
-        "@firebase/app-compat": "0.4.2",
+        "@firebase/ai": "2.1.0",
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-compat": "0.2.24",
+        "@firebase/app": "0.14.1",
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-compat": "0.4.0",
+        "@firebase/app-compat": "0.5.1",
         "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.10.8",
-        "@firebase/auth-compat": "0.5.28",
-        "@firebase/data-connect": "0.3.10",
-        "@firebase/database": "1.0.20",
-        "@firebase/database-compat": "2.0.11",
-        "@firebase/firestore": "4.8.0",
-        "@firebase/firestore-compat": "0.3.53",
-        "@firebase/functions": "0.12.9",
-        "@firebase/functions-compat": "0.3.26",
-        "@firebase/installations": "0.6.18",
-        "@firebase/installations-compat": "0.2.18",
-        "@firebase/messaging": "0.12.22",
-        "@firebase/messaging-compat": "0.2.22",
-        "@firebase/performance": "0.7.7",
-        "@firebase/performance-compat": "0.2.20",
-        "@firebase/remote-config": "0.6.5",
-        "@firebase/remote-config-compat": "0.2.18",
-        "@firebase/storage": "0.13.14",
-        "@firebase/storage-compat": "0.3.24",
-        "@firebase/util": "1.12.1"
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-compat": "0.6.0",
+        "@firebase/data-connect": "0.3.11",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-compat": "2.1.0",
+        "@firebase/firestore": "4.9.0",
+        "@firebase/firestore-compat": "0.4.0",
+        "@firebase/functions": "0.13.0",
+        "@firebase/functions-compat": "0.4.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-compat": "0.2.19",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/messaging-compat": "0.2.23",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-compat": "0.2.22",
+        "@firebase/remote-config": "0.6.6",
+        "@firebase/remote-config-compat": "0.2.19",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-compat": "0.4.0",
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/flat-cache": {
@@ -11206,7 +11231,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -16631,7 +16656,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -18631,9 +18656,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
-      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.1.tgz",
+      "integrity": "sha512-rHY3vHXRbkSfhG6fH8zYQdth/BtDgXXuR2pHF++1f/EBkI8zkgM5XWfsC3BvOoW9pr1CvZ1qQCxhCEsbNgT50g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -18648,7 +18673,7 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
+        "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.8",
     "expo-web-browser": "~14.2.0",
-    "firebase": "^11.0.0",
+    "firebase": "^12.1.0",
     "i18next": "^25.3.2",
     "react": "19.1.1",
     "react-dom": "19.1.1",
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@expo/ngrok": "^4.1.3",
+    "@firebase/rules-unit-testing": "^4.0.1",
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.2.2",
     "@types/jest": "^29.5.14",

--- a/tests/rules/gifts.test.ts
+++ b/tests/rules/gifts.test.ts
@@ -1,0 +1,35 @@
+import { initializeTestEnvironment, assertFails } from '@firebase/rules-unit-testing';
+import fs from 'fs';
+
+let testEnv: any;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'whisplist-test',
+    firestore: {
+      rules: fs.readFileSync('firestore.rules', 'utf8'),
+    },
+  });
+
+  await testEnv.withSecurityRulesDisabled(async (context: any) => {
+    const adminDb = context.firestore();
+    await adminDb.doc('wishes/wish1').set({ userId: 'user1' });
+    await adminDb.doc('wishes/wish1/gifts/gift1').set({ recipientId: 'user1', amount: 10 });
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+test('unauthorized user cannot read gift', async () => {
+  const db = testEnv.authenticatedContext('user2').firestore();
+  const giftRef = db.doc('wishes/wish1/gifts/gift1');
+  await assertFails(giftRef.get());
+});
+
+test('unauthorized user cannot write gift', async () => {
+  const db = testEnv.authenticatedContext('user2').firestore();
+  const giftRef = db.doc('wishes/wish1/gifts/gift2');
+  await assertFails(giftRef.set({ recipientId: 'user1', amount: 5 }));
+});


### PR DESCRIPTION
## Summary
- Limit wish gift writes to the wish owner or gift recipient
- Add Firestore security tests to ensure unauthorized users cannot read or write gifts
- Upgrade Firebase deps for testing

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError from firebase compat modules when loading rules test)*

------
https://chatgpt.com/codex/tasks/task_e_689b962f498c8327af8cf5da3a725994