### PR TITLE
Fix missing lastDoc reference in feed loader

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -129,8 +129,15 @@ export default function Page() {
     stopRecording,
     reset: resetRecorder,
   } = useAudioRecorder();
-  const { wishList, loading, error, refreshing, onRefresh, loadMore } =
-    useFeedLoader(user);
+  const {
+    wishList,
+    loading,
+    error,
+    refreshing,
+    onRefresh,
+    loadMore,
+    lastDoc,
+  } = useFeedLoader(user);
   const [searchTerm, setSearchTerm] = useState('');
   const [filterType, setFilterType] = useState<
     'all' | 'wish' | 'confession' | 'advice' | 'dream'

--- a/hooks/useFeedLoader.ts
+++ b/hooks/useFeedLoader.ts
@@ -141,6 +141,7 @@ export const useFeedLoader = (user: any) => {
     refreshing,
     onRefresh,
     loadMore,
+    lastDoc,
   };
 };
 


### PR DESCRIPTION
## Summary
- expose lastDoc state from useFeedLoader hook
- consume lastDoc in tabs index to render Load More button

## Testing
- `npm test` *(fails: Jest failed to parse firebase/compat database ESM in tests/rules/gifts.test.ts)*
- `npm run lint`
- `npm run typecheck` *(fails: cannot find modules for firebase-functions and others)*

------
https://chatgpt.com/codex/tasks/task_e_689b9d1ae78483278aa091045b688d45