### PR TITLE
Add wish deletion capability with owner checks

### DIFF
--- a/app/wish/[id].tsx
+++ b/app/wish/[id].tsx
@@ -10,6 +10,7 @@ import {
   setFulfillmentLink,
   createGiftCheckout,
   updateWish,
+  deleteWish,
 } from '../../helpers/wishes';
 import {
   listenWishComments,
@@ -33,7 +34,6 @@ import {
   collectionGroup,
   updateDoc,
   setDoc,
-  deleteDoc,
 } from 'firebase/firestore'; // ✅ Keep only if used directly in this file
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -578,7 +578,7 @@ export default function Page() {
         style: 'destructive',
         onPress: async () => {
           try {
-            await deleteDoc(doc(db, 'wishes', id as string));
+            await deleteWish(id as string);
             router.back();
           } catch (err) {
             logger.error('❌ Failed to delete wish:', err);

--- a/components/WishCard.tsx
+++ b/components/WishCard.tsx
@@ -7,6 +7,7 @@ import {
   Animated,
   Share,
   View,
+  Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Linking from 'expo-linking';
@@ -14,7 +15,7 @@ import { useRouter } from 'expo-router';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useSavedWishes } from '@/contexts/SavedWishesContext';
 import type { Wish } from '../types/Wish';
-import { updateWishReaction } from '../helpers/wishes';
+import { updateWishReaction, deleteWish } from '../helpers/wishes';
 import { db } from '../firebase';
 import { collection, getDocs, doc, onSnapshot } from 'firebase/firestore';
 import { formatTimeLeft } from '../helpers/time';
@@ -147,6 +148,24 @@ export const WishCard: React.FC<{
     }
   }, [wish.id]);
 
+  const handleDelete = useCallback(() => {
+    if (!wish.id) return;
+    Alert.alert(t('common.delete'), 'Are you sure?', [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('common.delete'),
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await deleteWish(wish.id!);
+          } catch (err) {
+            logger.warn('Failed to delete wish', err);
+          }
+        },
+      },
+    ]);
+  }, [wish.id, t]);
+
   return (
     <Animated.View
       style={[
@@ -233,6 +252,13 @@ export const WishCard: React.FC<{
             return t('wish.hoursLeft', { hours: hrs });
           })()}
         </Text>
+      )}
+      {user?.uid === wish.userId && (
+        <TouchableOpacity onPress={handleDelete} style={styles.reportButton}>
+          <Text style={[styles.reactionText, { color: '#f87171' }]}>
+            {t('common.delete')}
+          </Text>
+        </TouchableOpacity>
       )}
       {onReport && (
         <TouchableOpacity onPress={onReport} style={styles.reportButton}>

--- a/firestore.rules
+++ b/firestore.rules
@@ -51,7 +51,8 @@ service cloud.firestore {
       // Everyone (including anonymous) can read wishes
       allow read: if true;
       allow create: if signedIn() && request.resource.data.userId == request.auth.uid;
-      allow update, delete: if signedIn() && request.auth.uid == resource.data.userId;
+      allow update: if signedIn() && request.auth.uid == resource.data.userId;
+      allow delete: if wishOwner(wishId);
 
       match /comments/{commentId} {
         // Allow anyone to read comments

--- a/helpers/wishes.ts
+++ b/helpers/wishes.ts
@@ -182,6 +182,11 @@ export async function updateWish(id: string, data: Partial<Wish>) {
   return updateDoc(ref, data);
 }
 
+export async function deleteWish(id: string) {
+  const ref = doc(db, 'wishes', id);
+  return deleteDoc(ref);
+}
+
 export async function updateWishReaction(
   id: string,
   emoji: ReactionType,

--- a/tests/wishes.test.ts
+++ b/tests/wishes.test.ts
@@ -8,6 +8,8 @@ jest.mock('firebase/firestore', () => ({
   where: jest.fn(),
   onSnapshot: jest.fn(),
   getDocs: jest.fn(),
+  doc: jest.fn(),
+  deleteDoc: jest.fn(),
 }));
 
 import { getFollowingIds } from '@/helpers/followers';
@@ -17,6 +19,7 @@ import {
   getTopBoostedCreators,
   createBoostCheckout,
   createGiftCheckout,
+  deleteWish,
 } from '@/helpers/wishes';
 import {
   collection,
@@ -26,6 +29,8 @@ import {
   where,
   onSnapshot,
   getDocs,
+  doc,
+  deleteDoc,
 } from 'firebase/firestore';
 
 describe('listenTrendingWishes', () => {
@@ -192,6 +197,27 @@ describe('checkout helpers', () => {
       },
     );
     expect(result).toEqual({ url: 'http://gift' });
+  });
+});
+
+describe('deleteWish', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes wish successfully', async () => {
+    (doc as jest.Mock).mockReturnValue('ref');
+    (deleteDoc as jest.Mock).mockResolvedValue(undefined);
+    await deleteWish('w1');
+    expect(doc).toHaveBeenCalledWith({}, 'wishes', 'w1');
+    expect(deleteDoc).toHaveBeenCalledWith('ref');
+  });
+
+  it('throws on unauthorized deletion', async () => {
+    const err = new Error('denied');
+    (doc as jest.Mock).mockReturnValue('ref');
+    (deleteDoc as jest.Mock).mockRejectedValue(err);
+    await expect(deleteWish('w1')).rejects.toThrow(err);
   });
 });
 


### PR DESCRIPTION
## Summary
- implement `deleteWish` helper
- allow wish owners to delete from cards and detail page
- secure Firestore rules to restrict deletion to owners
- test wish deletion success and unauthorized cases

## Testing
- `npm test` *(fails: Test suite failed to run: SyntaxError: Cannot use import statement outside a module in tests/rules/gifts.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_689bc5c841588327b6d4cc8442933cef